### PR TITLE
implement edit storage page

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import NotePage from './NotePage'
 import { useRouteParams } from '../lib/router'
 import { StyledNotFoundPage } from './styled'
-import StorageCreate from './Storage/StorageCreate'
+import { StorageEdit, StorageCreate } from './Storage'
+import { useDb } from '../lib/db'
 
 export default () => {
   const routeParams = useRouteParams()
+  const db = useDb()
   switch (routeParams.name) {
     case 'storages.allNotes':
     case 'storages.notes':
@@ -14,6 +16,13 @@ export default () => {
       return <NotePage />
     case 'storages.create':
       return <StorageCreate />
+    case 'storages.edit':
+      const storage = db.storageMap[routeParams.storageId]
+      if (storage != null) {
+        return <StorageEdit storage={storage} />
+      } else {
+        break
+      }
   }
   return (
     <StyledNotFoundPage>

--- a/src/components/Storage/CloudStorageSelector.tsx
+++ b/src/components/Storage/CloudStorageSelector.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react'
+import {
+  CloudStorage,
+  createStorage,
+  User,
+  useUserCloudInfo
+} from '../../lib/accounts'
+
+interface CloudStorageSelectProps {
+  name?: string
+  user: User
+  onSelect: (storage: CloudStorage) => void
+  onErr?: () => void
+  buttonText?: string
+}
+
+export default ({
+  name,
+  user,
+  onSelect: onLink,
+  onErr,
+  buttonText
+}: CloudStorageSelectProps) => {
+  const [storageName, setStorageName] = useState(name)
+  const [isLoading, setIsLoading] = useState(false)
+  const [active, setActive] = useState(0)
+  const [userInfo, updateUserInfo] = useUserCloudInfo(user)
+
+  if (userInfo === 'loading') {
+    return <div>Loading...</div>
+  }
+
+  const { subscription, storages } = userInfo
+  const canCreateCloudStorages = subscription != null || storages.length < 1
+
+  const createStorageCallback = async () => {
+    setIsLoading(true)
+    const cloudStorage =
+      active > 0
+        ? storages.filter(storage => storage.id === active)[0]
+        : await createStorage(name || '', user)
+
+    if (cloudStorage === 'SubscriptionRequired') {
+      onErr != null ? onErr() : null
+    } else {
+      updateUserInfo()
+      onLink(cloudStorage)
+    }
+    setIsLoading(false)
+  }
+
+  return (
+    <div>
+      {!canCreateCloudStorages && (
+        <>
+          <p>You need to upgrade your plan to add a new storage cloud</p>
+          <p>Current Plan: Basic</p>
+          <p>New Plan: Premium ($3.00/month)</p>
+          <button>Upgrade</button>
+        </>
+      )}
+
+      {canCreateCloudStorages && (
+        <>
+          <div>
+            <label>Link or Create Storage</label>
+            <select
+              value={active}
+              onChange={({ target: { value } }) =>
+                setActive(parseInt(value, 10))
+              }
+            >
+              <option value={0}>Create New</option>
+              {storages.map(storage => (
+                <option key={storage.id} value={storage.id}>
+                  {storage.name} (id:{storage.id})
+                </option>
+              ))}
+            </select>
+          </div>
+          {active === 0 && (
+            <div>
+              <label>Cloud Storage Name</label>
+              <input
+                type='text'
+                value={storageName !== '' ? storageName : name}
+                onChange={e => setStorageName(e.target.value)}
+              />
+            </div>
+          )}
+          <div>
+            <button onClick={createStorageCallback}>
+              {!isLoading ? buttonText || 'Link Storage' : 'Creating...'}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/Storage/StorageCreate.tsx
+++ b/src/components/Storage/StorageCreate.tsx
@@ -6,86 +6,32 @@
  * default create new
  * dont limit to non-linked for now
  */
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { usePreferences } from '../../lib/preferences'
 import { Section, SectionHeader } from '../PreferencesModal/styled'
 import { useTranslation } from 'react-i18next'
 import { useDb } from '../../lib/db'
-import {
-  getStorages,
-  getSubscription,
-  Subscription,
-  CloudStorage,
-  createStorage
-} from '../../lib/accounts'
+import { CloudStorage } from '../../lib/accounts'
 import LoginButton from '../atoms/LoginButton'
-
-interface UserCloudInfo {
-  storages: CloudStorage[]
-  subscription: Subscription | undefined
-}
+import CloudStorageSelector from './CloudStorageSelector'
 
 export default () => {
   const db = useDb()
   const { preferences } = usePreferences()
   const { t } = useTranslation()
   const [localName, setLocalName] = useState('')
-  const [link, setLink] = useState<number>(0)
-  const [cloudName, setCloudName] = useState('')
-  const [useSameName, setUseSameName] = useState(true)
   const [storageType, setStorageType] = useState<'cloud' | 'local'>('cloud')
-  const [cloudInfo, setCloudInfo] = useState<UserCloudInfo>({
-    storages: [],
-    subscription: undefined
-  })
-  const [isLoading, setLoading] = useState(false)
 
   const user = preferences['general.accounts'][0]
 
-  useEffect(() => {
-    if (user != null) {
-      Promise.all([getStorages(user), getSubscription(user)])
-        .then(([storages, subscription]) => [
-          setCloudInfo({
-            storages,
-            subscription
-          })
-        ])
-        .catch(console.error)
-    }
-  }, [user])
-
   const isLoggedIn = user != null
-  const canCreateCloudStorages =
-    cloudInfo.subscription != null || cloudInfo.storages.length === 0
 
-  const createStorageCallback = async () => {
-    setLoading(true)
+  const createStorageCallback = async (cloudStorage?: CloudStorage) => {
     const newStorage = await db.createStorage(localName)
 
-    if (storageType === 'cloud') {
-      let cloudLink = link
-      if (link === 0) {
-        const cloud = await createStorage(
-          useSameName ? localName : cloudName,
-          user
-        )
-        if (cloud !== 'SubscriptionRequired') {
-          cloudLink = cloud.id
-          setCloudInfo({
-            ...cloudInfo,
-            storages: [...cloudInfo.storages, cloud]
-          })
-        } else {
-          // TODO: Toast error
-        }
-      }
-      if (cloudLink !== 0) {
-        await db.addCloudLink(newStorage.id, cloudLink)
-        // TODO: sync db after adding
-      }
+    if (cloudStorage != null) {
+      db.setCloudLink(newStorage.id, cloudStorage)
     }
-    setLoading(false)
   }
 
   return (
@@ -118,7 +64,7 @@ export default () => {
       <Section>
         {storageType === 'local' && (
           <>
-            <button onClick={createStorageCallback}>Add Storage</button>
+            <button onClick={() => createStorageCallback()}>Add Storage</button>
           </>
         )}
         {!isLoggedIn && storageType === 'cloud' && (
@@ -127,51 +73,13 @@ export default () => {
             <LoginButton />
           </>
         )}
-        {isLoggedIn && storageType === 'cloud' && !canCreateCloudStorages && (
-          <>
-            <p>You need to upgrade your plan to add a new storage cloud</p>
-            <p>Current Plan: Basic</p>
-            <p>New Plan: Premium ($3.00/month)</p>
-            <button>Upgrade</button>
-          </>
-        )}
-
-        {isLoggedIn && storageType === 'cloud' && canCreateCloudStorages && (
-          <>
-            <label>Link or Create Storage</label>
-            <select
-              value={link}
-              onChange={({ target: { value } }) => setLink(parseInt(value, 10))}
-            >
-              <option value={0}>Create New</option>
-              {cloudInfo.storages.map(storage => (
-                <option key={storage.id} value={storage.id}>
-                  {storage.name} (id:{storage.id})
-                </option>
-              ))}
-            </select>
-            <input
-              type='checkbox'
-              checked={useSameName}
-              onChange={() => setUseSameName(!useSameName)}
-            />
-            <label>Use same name</label>
-            {!useSameName && (
-              <div>
-                <label>Cloud Storage Name</label>
-                <input
-                  type='text'
-                  value={cloudName}
-                  onChange={e => setCloudName(e.target.value)}
-                />
-              </div>
-            )}
-            <div>
-              <button onClick={createStorageCallback}>
-                {!isLoading ? 'Add Storage' : '...'}
-              </button>
-            </div>
-          </>
+        {isLoggedIn && storageType === 'cloud' && (
+          <CloudStorageSelector
+            user={user}
+            name={localName}
+            onSelect={createStorageCallback}
+            buttonText='Add Storage'
+          />
         )}
       </Section>
     </div>

--- a/src/components/Storage/StorageEdit.tsx
+++ b/src/components/Storage/StorageEdit.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useState } from 'react'
+import { Section, SectionHeader } from '../PreferencesModal/styled'
+import CloudStorageSelector from './CloudStorageSelector'
+import { usePreferences } from '../../lib/preferences'
+import { useDb } from '../../lib/db'
+import { CloudStorage } from '../../lib/accounts'
+import { NoteStorage } from '../../lib/db/types'
+import { useRouter } from '../../lib/router'
+import { useDebounce } from 'react-use'
+import LoginButton from '../atoms/LoginButton'
+
+interface StorageEditProps {
+  storage: NoteStorage
+}
+
+export default ({ storage }: StorageEditProps) => {
+  const db = useDb()
+  const router = useRouter()
+  const { preferences } = usePreferences()
+  const [name, setName] = useState(storage.name)
+
+  const linkCallback = useCallback(
+    (cloudStorage: CloudStorage) => {
+      db.setCloudLink(storage.id, cloudStorage)
+      // TODO: sync
+    },
+    [storage]
+  )
+
+  const unlinkCallback = useCallback(() => {
+    db.setCloudLink(storage.id, null)
+  }, [storage])
+
+  const removeCallback = useCallback(() => {
+    db.removeStorage(storage.id)
+    router.push('/app')
+  }, [storage])
+
+  useDebounce(
+    () => {
+      db.renameStorage(storage.id, name)
+    },
+    1000,
+    [name]
+  )
+
+  const user = preferences['general.accounts'][0]
+
+  return (
+    <div>
+      <Section>
+        <SectionHeader>Edit Storage</SectionHeader>
+        <div>
+          <label>
+            Storage Name{' '}
+            <input
+              value={name}
+              onChange={e => setName(e.target.value)}
+              type='text'
+            />
+          </label>
+          <span onClick={removeCallback}>Delete Storage</span>
+        </div>
+        <div>
+          <h2>Cloud Storage</h2>
+          {storage.cloudStorage != null ? (
+            <p>
+              Linked Storage: {storage.cloudStorage.name} (ID:
+              {storage.cloudStorage.id}){' '}
+              <span onClick={unlinkCallback}>Unlink</span>
+            </p>
+          ) : (
+            <div>
+              {user == null && (
+                <>
+                  <p>You need to sign in to add a cloud folder</p>
+                  <LoginButton />
+                </>
+              )}
+              {user != null && (
+                <>
+                  <p>This storage is not linked yet</p>
+                  <CloudStorageSelector
+                    user={user}
+                    onSelect={linkCallback}
+                    name={storage.name}
+                  />
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/src/components/Storage/index.ts
+++ b/src/components/Storage/index.ts
@@ -1,0 +1,3 @@
+export { default as CloudStorageSelector } from './CloudStorageSelector'
+export { default as StorageCreate } from './StorageCreate'
+export { default as StorageEdit } from './StorageEdit'

--- a/src/lib/accounts/users.ts
+++ b/src/lib/accounts/users.ts
@@ -1,9 +1,17 @@
 import { usePreferences } from '../preferences'
+import { CloudStorage, getStorages } from './api/storage'
+import { Subscription, getSubscription } from './api/subscription'
+import { useState, useEffect } from 'react'
 
 export interface User {
   token: string
   name: string
   id: number
+}
+
+export interface UserCloudInfo {
+  storages: CloudStorage[]
+  subscription: Subscription | undefined
 }
 
 interface UserRepo {
@@ -27,6 +35,37 @@ export const useUsers = (): [User[], UserRepo] => {
   }
 
   return [users, repo]
+}
+
+const cache: { [key: number]: UserCloudInfo } = {}
+export const useUserCloudInfo = (
+  user: User
+): ['loading' | UserCloudInfo, () => void] => {
+  const [info, setInfo] = useState<'loading' | UserCloudInfo>(() => {
+    return cache[user.id] != undefined ? cache[user.id] : 'loading'
+  })
+  const [forceFlag, setForceFlag] = useState(true)
+
+  useEffect(() => {
+    let isSubscribed = true
+    getUserCloudInfo(user).then(info => {
+      cache[user.id] = info
+      if (isSubscribed) {
+        setInfo(info)
+      }
+    })
+    return () => {
+      isSubscribed = false
+    }
+  }, [user, forceFlag])
+
+  return [info, () => setForceFlag(!forceFlag)]
+}
+
+const getUserCloudInfo = (user: User): Promise<UserCloudInfo> => {
+  return Promise.all([getStorages(user), getSubscription(user)]).then(
+    ([storages, subscription]) => ({ storages, subscription })
+  )
 }
 
 const removeUser = (user: User, users: User[]) => {

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -14,6 +14,10 @@ export type ExceptRev<D extends PouchDB.Core.RevisionIdMeta> = Except<D, '_rev'>
 export interface NoteStorageData {
   id: string
   name: string
+  cloudStorage?: {
+    id: number
+    name: string
+  }
 }
 
 export type NoteDocEditibleProps = {
@@ -69,8 +73,6 @@ export type NoteIdSet = Set<string>
 export type NoteStorage = NoteStorageData &
   AllPopulatedDocsMap & {
     db: NoteDb
-  } & {
-    cloudStorageId?: number
   }
 
 export type PopulatedFolderDoc = FolderDoc & {

--- a/src/lib/router/utils.ts
+++ b/src/lib/router/utils.ts
@@ -46,6 +46,11 @@ export interface StorageCreate extends BaseRouteParams {
   name: 'storages.create'
 }
 
+export interface StorageEdit extends BaseRouteParams {
+  name: 'storages.edit'
+  storageId: string
+}
+
 export interface StorageAllNotes extends BaseRouteParams {
   name: 'storages.allNotes'
   storageId: string
@@ -78,6 +83,7 @@ export interface UnknownRouteparams extends BaseRouteParams {
 
 export type AllRouteParams =
   | StorageCreate
+  | StorageEdit
   | StorageAllNotes
   | StorageNotesRouteParams
   | StorageTrashCanRouteParams
@@ -104,6 +110,13 @@ export const useRouteParams = () => {
       }
     }
     const storageId = names[1]
+
+    if (names[2] == null) {
+      return {
+        name: 'storages.edit',
+        storageId
+      }
+    }
 
     if (names[2] === 'notes') {
       const restNames = names.slice(3)

--- a/src/lib/utils/predicates.ts
+++ b/src/lib/utils/predicates.ts
@@ -28,6 +28,22 @@ export const schema = <T extends PredicateSchema>(
     return true
   })
 
+export const optional = <T extends PredicateSchema>(
+  predicateSchema: T
+): BasePredicate<ValidatedObject<T>> =>
+  ow.optional.object.is(value => {
+    const predicateEntries = Object.entries(predicateSchema)
+    for (const [key, predicate] of predicateEntries) {
+      try {
+        ow(value[key], predicate)
+      } catch (error) {
+        return false
+      }
+    }
+
+    return true
+  })
+
 export function isValid<T>(
   value: any,
   predicate: BasePredicate<T>


### PR DESCRIPTION
Implement edit storage page

- Ability to link and unlink storage
- Extracted cloud storage selection into separate component shared across `StorageCreate` and `StorageEdit` componenets.
- Add `name` information for linked cloud storage on local storage information
  - required implementing an `optional` predicate
- Local storage name saves using a debounce
- Cloud storage name now always shows on create but defaults to local storage
- Cloud user info is cached

![note-app-storages-edit1](https://user-images.githubusercontent.com/19530989/69294879-90877400-0c4e-11ea-8a1f-e4fb16804e57.png)
![note-app-storages-edit2](https://user-images.githubusercontent.com/19530989/69294883-90877400-0c4e-11ea-8546-4a4980b3620f.png)
![note-app-storages-edit3](https://user-images.githubusercontent.com/19530989/69294887-90877400-0c4e-11ea-9aa4-f7e9dde4d1ca.png)


