### PR TITLE
NoteItem preview style fix

### DIFF
--- a/src/components/NotePage/NoteList/NoteItem.tsx
+++ b/src/components/NotePage/NoteList/NoteItem.tsx
@@ -44,6 +44,9 @@ export const StyledNoteListItem = styled.div`
   }
 
   .preview {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `
 


### PR DESCRIPTION
<img width="264" alt="Screen Shot 2019-12-12 at 10 54 43" src="https://user-images.githubusercontent.com/45586198/70675918-de335180-1ccd-11ea-825c-11b874dab5b7.png">

to

<img width="261" alt="Screen Shot 2019-12-12 at 10 54 18" src="https://user-images.githubusercontent.com/45586198/70675929-e25f6f00-1ccd-11ea-88b1-f7ad03e46efe.png">
