### PR TITLE
Restructure root folder

### DIFF
--- a/src/components/NotePage/NoteList/NoteList.tsx
+++ b/src/components/NotePage/NoteList/NoteList.tsx
@@ -73,7 +73,7 @@ type NoteListProps = {
   currentNoteIndex: number
   search: string
   notes: PopulatedNoteDoc[]
-  createNote: () => Promise<void>
+  createNote?: () => Promise<void>
   setSearchInput: (input: string) => void
   navigateDown: () => void
   navigateUp: () => void
@@ -131,7 +131,7 @@ const NoteList = ({
           />
           <IconLoupe className='icon' size='0.8em' />
         </div>
-        {currentStorageId != null && (
+        {currentStorageId != null && createNote != null && (
           <button className='newNoteButton' onClick={createNote}>
             <IconEdit size='0.8em' />
           </button>

--- a/src/components/NotePage/NotePage.tsx
+++ b/src/components/NotePage/NotePage.tsx
@@ -175,6 +175,8 @@ export default () => {
     }
   }, [db, routeParams, storageId, setLastCreatedNoteId])
 
+  const showCreateNoteInList = routeParams.name === 'storages.notes'
+
   const breadCrumbs = useMemo(() => {
     if (currentNote == null || currentNote.folderPathname === '/')
       return undefined
@@ -260,7 +262,7 @@ export default () => {
           setSearchInput={setSearchInput}
           currentStorageId={storageId}
           notes={filteredNotes}
-          createNote={createNote}
+          createNote={showCreateNoteInList ? createNote : undefined}
           basePathname={currentPathnameWithoutNoteId}
           navigateDown={navigateDown}
           navigateUp={navigateUp}

--- a/src/components/SideNavigator/FolderListFragment.tsx
+++ b/src/components/SideNavigator/FolderListFragment.tsx
@@ -9,7 +9,7 @@ import { useGeneralStatus } from '../../lib/generalStatus'
 import ControlButton from './ControlButton'
 import { getFolderItemId } from '../../lib/nav'
 import { getTransferrableNoteData } from '../../lib/dnd'
-import { IconAddRound, IconBook, IconFile, IconFileOpen } from '../icons'
+import { IconAddRound, IconFile, IconFileOpen } from '../icons'
 
 interface FolderListFragmentProps {
   storage: NoteStorage
@@ -122,9 +122,6 @@ const FolderListFragment = ({
     )
   }, [folderPathnameListExceptRoot, storageId, sideNavOpenedItemSet])
 
-  const rootFolderIsActive =
-    currentPathnameWithoutNoteId === `/app/storages/${storageId}/notes`
-
   const createDropHandler = (folderPathname: string) => {
     return async (event: React.DragEvent) => {
       const transferrableNoteData = getTransferrableNoteData(event)
@@ -176,23 +173,6 @@ const FolderListFragment = ({
   }
   return (
     <>
-      <SideNavigatorItem
-        depth={1}
-        active={rootFolderIsActive}
-        label='All Notes'
-        icon={
-          rootFolderIsActive ? (
-            <IconBook color='currentColor' />
-          ) : (
-            <IconBook color='currentColor' />
-          )
-        }
-        onClick={createOnFolderItemClickHandler('/')}
-        onDragOver={event => {
-          event.preventDefault()
-        }}
-        onDrop={createDropHandler('/')}
-      />
       {openedFolderPathnameList.map((folderPathname: string) => {
         const nameElements = folderPathname.split('/').slice(1)
         const folderName = nameElements[nameElements.length - 1]

--- a/src/components/SideNavigator/FolderListFragment.tsx
+++ b/src/components/SideNavigator/FolderListFragment.tsx
@@ -60,6 +60,14 @@ const FolderListFragment = ({
       popup(event, [
         {
           type: MenuTypes.Normal,
+          label: 'New Note',
+          enabled: folderPathname !== '/',
+          onClick: async () => {
+            createNote(storageId, { folderPathname })
+          }
+        },
+        {
+          type: MenuTypes.Normal,
           label: 'New Folder',
           onClick: async () => {
             showPromptToCreateFolder(folderPathname)

--- a/src/components/SideNavigator/FolderListFragment.tsx
+++ b/src/components/SideNavigator/FolderListFragment.tsx
@@ -37,11 +37,8 @@ const FolderListFragment = ({
 
   const currentPathnameWithoutNoteId = usePathnameWithoutNoteId()
 
-  const folderPathnameListExceptRoot = useMemo(() => {
-    const folderPathnameList = Object.keys(folderMap).sort((a, b) =>
-      a.localeCompare(b)
-    )
-    return folderPathnameList.slice(1)
+  const folderPathnames = useMemo(() => {
+    return Object.keys(folderMap).sort((a, b) => a.localeCompare(b))
   }, [folderMap])
 
   const createOnFolderItemClickHandler = (folderPathname: string) => {
@@ -101,7 +98,7 @@ const FolderListFragment = ({
   }
 
   const folderSetWithSubFolders = useMemo(() => {
-    return folderPathnameListExceptRoot.reduce((folderSet, folderPathname) => {
+    return folderPathnames.reduce((folderSet, folderPathname) => {
       if (folderPathname !== '/') {
         const nameElements = folderPathname.slice(1).split('/')
         const parentFolderPathname =
@@ -110,17 +107,17 @@ const FolderListFragment = ({
       }
       return folderSet
     }, new Set())
-  }, [folderPathnameListExceptRoot])
+  }, [folderPathnames])
 
   const openedFolderPathnameList = useMemo(() => {
-    const tree = getFolderNameElementTree(folderPathnameListExceptRoot)
+    const tree = getFolderNameElementTree(folderPathnames)
     return getOpenedFolderPathnameList(
       tree,
       storageId,
       sideNavOpenedItemSet,
       '/'
     )
-  }, [folderPathnameListExceptRoot, storageId, sideNavOpenedItemSet])
+  }, [folderPathnames, storageId, sideNavOpenedItemSet])
 
   const createDropHandler = (folderPathname: string) => {
     return async (event: React.DragEvent) => {

--- a/src/components/SideNavigator/SideNavigator.tsx
+++ b/src/components/SideNavigator/SideNavigator.tsx
@@ -318,6 +318,9 @@ export default () => {
                 onFoldButtonClick={() => {
                   toggleSideNavOpenedItem(itemId)
                 }}
+                onClick={() => {
+                  push(`/app/storages/${storage.id}/notes`)
+                }}
                 onContextMenu={event => {
                   event.preventDefault()
                   popup(event, [

--- a/src/lib/db/NoteDb.spec.ts
+++ b/src/lib/db/NoteDb.spec.ts
@@ -421,7 +421,7 @@ describe('NoteDb', () => {
         content: 'test content',
         tags: [],
         bookmarked: false,
-        folderPathname: '/',
+        folderPathname: '/default',
         data: {},
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
@@ -436,7 +436,7 @@ describe('NoteDb', () => {
         content: 'test content',
         tags: [],
         bookmarked: false,
-        folderPathname: '/',
+        folderPathname: '/default',
         data: {},
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
@@ -502,7 +502,7 @@ describe('NoteDb', () => {
         content: 'changed content',
         tags: [],
         bookmarked: false,
-        folderPathname: '/',
+        folderPathname: '/default',
         data: {},
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
@@ -517,7 +517,7 @@ describe('NoteDb', () => {
         content: 'changed content',
         tags: [],
         bookmarked: false,
-        folderPathname: '/',
+        folderPathname: '/default',
         data: {},
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
@@ -646,19 +646,19 @@ describe('NoteDb', () => {
       const note1 = await noteDb.createNote({
         title: 'test title1',
         content: 'test content1',
-        folderPathname: '/',
+        folderPathname: '/default',
         tags: ['tag1']
       })
       const note2 = await noteDb.createNote({
         title: 'test title2',
         content: 'test content2',
-        folderPathname: '/',
+        folderPathname: '/default',
         tags: ['tag1', 'tag2']
       })
       const note3 = await noteDb.createNote({
         title: 'test title3',
         content: 'test content3',
-        folderPathname: '/',
+        folderPathname: '/default',
         tags: ['tag2']
       })
 
@@ -672,7 +672,7 @@ describe('NoteDb', () => {
           _rev: note1._rev,
           title: 'test title1',
           content: 'test content1',
-          folderPathname: '/',
+          folderPathname: '/default',
           tags: ['tag1'],
           bookmarked: false,
           data: {},
@@ -685,7 +685,7 @@ describe('NoteDb', () => {
           _rev: note2._rev,
           title: 'test title2',
           content: 'test content2',
-          folderPathname: '/',
+          folderPathname: '/default',
           tags: ['tag1', 'tag2'],
           bookmarked: false,
           data: {},
@@ -705,7 +705,7 @@ describe('NoteDb', () => {
           _rev: note2._rev,
           title: 'test title2',
           content: 'test content2',
-          folderPathname: '/',
+          folderPathname: '/default',
           tags: ['tag1', 'tag2'],
           data: {},
           bookmarked: false,
@@ -718,7 +718,7 @@ describe('NoteDb', () => {
           _rev: note3._rev,
           title: 'test title3',
           content: 'test content3',
-          folderPathname: '/',
+          folderPathname: '/default',
           tags: ['tag2'],
           bookmarked: false,
           data: {},
@@ -887,13 +887,13 @@ describe('NoteDb', () => {
       const note1 = await noteDb.createNote({
         title: 'test title1',
         content: 'test content1',
-        folderPathname: '/',
+        folderPathname: '/default',
         tags: ['tag1']
       })
       const note2 = await noteDb.createNote({
         title: 'test title2',
         content: 'test content2',
-        folderPathname: '/',
+        folderPathname: '/default',
         tags: ['tag1', 'tag2']
       })
 
@@ -1062,7 +1062,6 @@ describe('NoteDb', () => {
       })
 
       expect(result.folderMap).toEqual({
-        '/': expect.anything(),
         '/test': expect.anything(),
         '/test/child folder': expect.anything(),
         '/test/child folder2': expect.anything()

--- a/src/lib/db/NoteDb.ts
+++ b/src/lib/db/NoteDb.ts
@@ -231,7 +231,7 @@ export default class NoteDb {
       title: '',
       content: '',
       tags: [],
-      folderPathname: '/',
+      folderPathname: '/default',
       data: {},
       bookmarked: false,
       ...noteProps,

--- a/src/lib/db/NoteDb.ts
+++ b/src/lib/db/NoteDb.ts
@@ -154,8 +154,8 @@ export default class NoteDb {
       const { doc } = row
       if (isNoteDoc(doc)) {
         map.noteMap[doc._id] = {
-          storageId: this.id,
-          ...doc
+          ...doc,
+          storageId: this.id
         } as PopulatedNoteDoc
       } else if (isFolderDoc(doc)) {
         map.folderMap[getFolderPathname(doc._id)] = doc

--- a/src/lib/db/NoteDb.ts
+++ b/src/lib/db/NoteDb.ts
@@ -85,6 +85,10 @@ export default class NoteDb {
       ...[...missingTagNameSet].map(tagName => this.upsertTag(tagName)),
       ...requiresUpdate.map(note => this.updateNote(note._id, note))
     ])
+
+    if (folderMap['/'] != null) {
+      await this.removeFolder('/')
+    }
   }
 
   async getFolder(path: string): Promise<FolderDoc | null> {

--- a/src/lib/db/NoteDb.ts
+++ b/src/lib/db/NoteDb.ts
@@ -130,7 +130,9 @@ export default class NoteDb {
 
   async doesParentFolderExistOrCreate(pathname: string) {
     const parentPathname = getParentFolderPathname(pathname)
-    await this.upsertFolder(parentPathname)
+    if (parentPathname !== '/') {
+      await this.upsertFolder(parentPathname)
+    }
   }
 
   async getAllDocsMap(): Promise<AllDocsMap> {

--- a/src/lib/db/store.spec.ts
+++ b/src/lib/db/store.spec.ts
@@ -116,7 +116,7 @@ describe('DbStore', () => {
 
       // Then
       expect(result.current.storageMap[storage!.id]!.folderMap).toEqual({
-        '/': expect.objectContaining({ pathname: '/' }),
+        '/default': expect.objectContaining({ pathname: '/default' }),
         '/test': expect.objectContaining({ pathname: '/test' })
       })
 
@@ -140,7 +140,7 @@ describe('DbStore', () => {
 
       // Then
       expect(result.current.storageMap[storage!.id]!.folderMap).toEqual({
-        '/': expect.objectContaining({ pathname: '/' }),
+        '/default': expect.objectContaining({ pathname: '/default' }),
         '/test': expect.objectContaining({ pathname: '/test' }),
         '/test/child folder': expect.objectContaining({
           pathname: '/test/child folder'
@@ -175,7 +175,7 @@ describe('DbStore', () => {
 
       // Then
       expect(result.current.storageMap[storage!.id]!.folderMap).toEqual({
-        '/': expect.objectContaining({ pathname: '/' })
+        '/default': expect.objectContaining({ pathname: '/default' })
       })
     })
 
@@ -194,7 +194,7 @@ describe('DbStore', () => {
 
       // Then
       expect(result.current.storageMap[storage!.id]!.folderMap).toEqual({
-        '/': expect.objectContaining({ pathname: '/' })
+        '/default': expect.objectContaining({ pathname: '/default' })
       })
     })
 
@@ -600,7 +600,7 @@ describe('DbStore', () => {
         // Then
         expect(
           result.current.storageMap[storage!.id]!.folderMap[
-            noteDoc!.folderPathname
+          noteDoc!.folderPathname
           ]
         ).toBeDefined()
       })

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -492,6 +492,7 @@ export function createDbStoreCreator(
         const parentFolderPathnamesToCheck = [
           ...getAllParentFolderPathnames(noteDoc.folderPathname)
         ].filter(aPathname => storage.folderMap[aPathname] == null)
+
         const parentFoldersToRefresh = await storage.db.getFoldersByPathnames(
           parentFolderPathnamesToCheck
         )
@@ -1240,8 +1241,6 @@ async function prepareStorage(
       storage.tagMap[tagName]!.noteIdSet.add(noteDoc._id)
     })
   }
-
-  console.log(storage.folderMap)
 
   return storage
 }

--- a/src/lib/db/utils.spec.ts
+++ b/src/lib/db/utils.spec.ts
@@ -119,13 +119,6 @@ describe('getAllParentFolderPathnames', () => {
 
     const result = getAllParentFolderPathnames(input)
 
-    expect(result).toEqual([
-      '/a/b/c/d/e',
-      '/a/b/c/d',
-      '/a/b/c',
-      '/a/b',
-      '/a',
-      '/'
-    ])
+    expect(result).toEqual(['/a/b/c/d/e', '/a/b/c/d', '/a/b/c', '/a/b', '/a'])
   })
 })

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -45,7 +45,7 @@ export function isFolderNameValid(name: string): boolean {
 }
 
 export function isFolderPathnameValid(pathname: string): boolean {
-  if (pathname === '/') return true
+  if (pathname === '/') return false
   if (!pathname.startsWith('/')) return false
   const [, ...folderNames] = pathname.split('/')
   return folderNames.every(isFolderNameValid)

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -121,7 +121,9 @@ export function getAllParentFolderPathnames(pathname: string) {
   let currentPathname = pathname
   do {
     currentPathname = getParentFolderPathname(currentPathname)
-    pathnames.push(currentPathname)
+    if (currentPathname !== '/') {
+      pathnames.push(currentPathname)
+    }
   } while (currentPathname !== '/')
   return pathnames
 }


### PR DESCRIPTION
- Users can see all notes among all folders from Storage name nav
- Delete the current root folder (All Notes) Root folder no longer exists, cannot be created.
- Create a default folder called "Default" automatically when storage is created
- Migrate notes in "All Notes" to "Default"
- Hide new note button other than UI that users choose the folder
- New note on right-click on the folder
- Users can not create note if there is no folder
- Fixed bug where synced notes would not update their storageId

![note-app-new-note-ctx](https://user-images.githubusercontent.com/19530989/71403032-d9798080-2671-11ea-94ad-304729586d96.png)
![note-app-no-notecreate](https://user-images.githubusercontent.com/19530989/71403033-d9798080-2671-11ea-8f13-6d37cc594af1.png)