### PR TITLE
Fixed error caused by using hooks inside of class component

### DIFF
--- a/src/components/Tutorials/TutorialsNoteDetail.tsx
+++ b/src/components/Tutorials/TutorialsNoteDetail.tsx
@@ -8,12 +8,12 @@ import { TutorialsNavigatorTreeItem } from '../../lib/tutorials'
 import { StyledNoteDetailContainer } from '../NotePage/NoteDetail/NoteDetail'
 import { ViewModeType } from '../../lib/generalStatus'
 import { IconEye, IconSplit, IconEdit } from '../icons'
-import { useTranslation } from 'react-i18next'
 
 type TutorialsNoteDetailProps = {
   note: TutorialsNavigatorTreeItem
   viewMode: ViewModeType
   toggleViewMode: (mode: ViewModeType) => void
+  t: (str: string) => Promise<void>
 }
 
 type TutorialsNoteDetailState = {
@@ -80,12 +80,10 @@ export default class TutorialsNoteDetail extends React.Component<
       <CustomizedMarkdownPreviewer content={this.state.noteContent} />
     )
 
-    const { t } = useTranslation()
-
     return (
       <StyledNoteDetailContainer>
         {note == null ? (
-          <p>{t('note.unselect')}</p>
+          <p>{this.props.t('note.unselect')}</p>
         ) : (
           <>
             <div className='titleSection'>

--- a/src/components/Tutorials/TutorialsPage.tsx
+++ b/src/components/Tutorials/TutorialsPage.tsx
@@ -248,6 +248,7 @@ export default ({ pathname }: TutorialsPageProps) => {
             note={selectedNote}
             viewMode={generalStatus.noteViewMode}
             toggleViewMode={toggleViewMode}
+            t={t}
           />
         )
       }


### PR DESCRIPTION
When clicking `tutorials`, I got errors.

I tried to change `TutorialsNoteDetail.tsx ` to function component, but it was a big deal than this, and it isn't a case that I can decide, I think.

So I fixed like this. 

![GIF](https://user-images.githubusercontent.com/33743343/71462112-aa8c1780-27f5-11ea-8cf3-d5f48c201c11.gif)

