### PR TITLE
Add  solarized dark to editor themes

### DIFF
--- a/src/components/CodeMirrorStyle.tsx
+++ b/src/components/CodeMirrorStyle.tsx
@@ -10,6 +10,9 @@ const ThemeLink = ({ theme }: ThemeLinkProps) => {
   if (theme == null || theme === 'default') {
     return null
   }
+  if (theme === 'solarized dark') {
+    theme = 'solarized'
+  }
   return (
     <link
       href={

--- a/src/components/CodeMirrorStyle.tsx
+++ b/src/components/CodeMirrorStyle.tsx
@@ -10,7 +10,7 @@ const ThemeLink = ({ theme }: ThemeLinkProps) => {
   if (theme == null || theme === 'default') {
     return null
   }
-  if (theme === 'solarized dark') {
+  if (theme === 'solarized-dark') {
     theme = 'solarized'
   }
   return (

--- a/src/components/atoms/CodeEditor.tsx
+++ b/src/components/atoms/CodeEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import CodeMirror from '../../lib/CodeMirror'
+import CodeMirror, { getCodeMirrorTheme } from '../../lib/CodeMirror'
 import styled from '../../lib/styled'
 import {
   EditorIndentTypeOptions,
@@ -48,7 +48,7 @@ class CodeEditor extends React.Component<CodeEditorProps> {
         : this.props.keyMap
     this.codeMirror = CodeMirror.fromTextArea(this.textAreaRef.current!, {
       ...defaultCodeMirrorOptions,
-      theme: this.props.theme == null ? 'default' : this.props.theme,
+      theme: getCodeMirrorTheme(this.props.theme),
       indentWithTabs: this.props.indentType === 'tab',
       indentUnit: indentSize,
       tabSize: indentSize,
@@ -77,7 +77,7 @@ class CodeEditor extends React.Component<CodeEditorProps> {
       this.codeMirror.setValue(this.props.value)
     }
     if (this.props.theme !== prevProps.theme) {
-      this.codeMirror.setOption('theme', this.props.theme)
+      this.codeMirror.setOption('theme', getCodeMirrorTheme(this.props.theme))
     }
     if (
       this.props.fontSize !== prevProps.fontSize ||

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -69,7 +69,7 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
         parent.properties.className != null
           ? [...parent.properties.className]
           : []
-      if (theme === 'solarized dark') {
+      if (theme === 'solarized-dark') {
         classNames.push(`cm-s-solarized`, `cm-s-dark`, 'CodeMirror')
       } else {
         classNames.push(`cm-s-${theme}`, 'CodeMirror')

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -45,10 +45,7 @@ function isElement(node: Node, tagName: string): node is Element {
   if (node == null) {
     return false
   }
-  if (node.tagName !== tagName) {
-    return false
-  }
-  return true
+  return node.tagName === tagName
 }
 
 function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
@@ -72,7 +69,12 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
         parent.properties.className != null
           ? [...parent.properties.className]
           : []
-      classNames.push(`cm-s-${theme}`, 'CodeMirror')
+      console.log(theme)
+      if (theme === 'solarized dark') {
+        classNames.push(`cm-s-solarized`, `cm-s-dark`, 'CodeMirror')
+      } else {
+        classNames.push(`cm-s-${theme}`, 'CodeMirror')
+      }
       if (lang != null) {
         classNames.push('language-' + lang)
       }

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -69,7 +69,6 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
         parent.properties.className != null
           ? [...parent.properties.className]
           : []
-      console.log(theme)
       if (theme === 'solarized dark') {
         classNames.push(`cm-s-solarized`, `cm-s-dark`, 'CodeMirror')
       } else {

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -9,7 +9,6 @@ import 'codemirror/lib/codemirror.css'
 import 'codemirror/keymap/sublime'
 import 'codemirror/keymap/emacs'
 import 'codemirror/keymap/vim'
-import 'codemirror/theme/solarized.css'
 
 const dispatchModeLoad = debounce(() => {
   window.dispatchEvent(new CustomEvent('codemirror-mode-load'))

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -9,6 +9,7 @@ import 'codemirror/lib/codemirror.css'
 import 'codemirror/keymap/sublime'
 import 'codemirror/keymap/emacs'
 import 'codemirror/keymap/vim'
+import 'codemirror/theme/solarized.css'
 
 const dispatchModeLoad = debounce(() => {
   window.dispatchEvent(new CustomEvent('codemirror-mode-load'))

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -19,6 +19,12 @@ export async function requireMode(mode: string) {
   dispatchModeLoad()
 }
 
+export function getCodeMirrorTheme(theme?: string) {
+  if (theme == null) return 'default'
+  if (theme === 'solarized-dark') return 'solarized dark'
+  return theme
+}
+
 function loadMode(_CodeMirror: any) {
   const memoizedModeResult = new Map<string, CodeMirror.ModeInfo | null>()
   function findModeByMIME(mime: string) {
@@ -57,7 +63,7 @@ export const themes = [
   'neo',
   'paraiso-light',
   'solarized',
-  'solarized dark',
+  'solarized-dark',
   'twilight',
   'zenburn',
   '3024-night',

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -57,6 +57,7 @@ export const themes = [
   'neo',
   'paraiso-light',
   'solarized',
+  'solarized dark',
   'twilight',
   'zenburn',
   '3024-night',


### PR DESCRIPTION
This is not 100% finished as I have run into an issue.

I have added the line to add solarized dark to the editor themes. This applies fine but not so when i add it to the code blocks. See image.

![image](https://user-images.githubusercontent.com/21989833/71747103-b10a3700-2e66-11ea-99a6-029dfc38e0b2.png)

I am happy to continue the work but would appreciate a pointer to help find out what is up.