### PR TITLE
Maximise on boot - rather than loading as a small screen

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -16,7 +16,7 @@ function createMainWindow() {
     windowOptions.titleBarStyle = 'hiddenInset'
   }
   const window = new BrowserWindow(windowOptions)
-
+  window.maximize()
   window.loadFile(path.join(__dirname, '../compiled/index.html'))
 
   window.on('closed', () => {


### PR DESCRIPTION
Instead of loading as a floating (non-maximised screen). Only tested on Mac.

![image](https://user-images.githubusercontent.com/21989833/71810391-3447aa80-306a-11ea-8aab-eea86295ed20.png)

Load as maximised when opening the app.

![image](https://user-images.githubusercontent.com/21989833/71809883-ebdbbd00-3068-11ea-9bfb-9dd2f67a7339.png)
