### PR TITLE
Change to edit mode when tap createNote button

### DIFF
--- a/src/components/NotePage/NotePage.tsx
+++ b/src/components/NotePage/NotePage.tsx
@@ -186,6 +186,7 @@ export default () => {
         }${note._id}`
       )
       dispatchNoteDetailFocusTitleInputEvent()
+      toggleViewMode('edit')
     }
   }, [createNote, replace, routeParams, storageId, setLastCreatedNoteId])
 


### PR DESCRIPTION
issue: https://github.com/BoostIO/BoostNote.next/issues/278

## Overview
Change to edit mode when you tap createNote button in view only mode

## GIF
![demo](https://user-images.githubusercontent.com/12893657/72201891-73c42b80-349c-11ea-8caa-2cacc25a1f4d.gif)
