### PR TITLE
【Suggestion】Show restore menu when select trashed note

### DIFF
--- a/src/components/NotePage/NoteList/NoteItem.tsx
+++ b/src/components/NotePage/NoteList/NoteItem.tsx
@@ -119,89 +119,86 @@ export default ({
       event.stopPropagation()
       event.preventDefault()
 
-      let menuItems: MenuItem[]
-      if (note.trashed) {
-        menuItems = [
-          {
-            type: MenuTypes.Normal,
-            label: t('note.restore'),
-            onClick: async () => {
-              untrashNote(note.storageId, note._id)
-            }
-          },
-          {
-            type: MenuTypes.Normal,
-            label: t('note.delete'),
-            onClick: async () => {
-              if (!note.trashed) {
-                trashNote(note.storageId, note._id)
-              } else {
-                messageBox({
-                  title: t('note.delete2'),
-                  message: t('note.deleteMessage'),
-                  iconType: DialogIconTypes.Warning,
-                  buttons: [t('note.delete2'), t('general.cancel')],
-                  defaultButtonIndex: 0,
-                  cancelButtonIndex: 1,
-                  onClose: (value: number | null) => {
-                    if (value === 0) {
-                      purgeNote(note.storageId, note._id)
+      const menuItems: MenuItem[] = note.trashed
+        ? [
+            {
+              type: MenuTypes.Normal,
+              label: t('note.restore'),
+              onClick: async () => {
+                untrashNote(note.storageId, note._id)
+              }
+            },
+            {
+              type: MenuTypes.Normal,
+              label: t('note.delete'),
+              onClick: async () => {
+                if (!note.trashed) {
+                  trashNote(note.storageId, note._id)
+                } else {
+                  messageBox({
+                    title: t('note.delete2'),
+                    message: t('note.deleteMessage'),
+                    iconType: DialogIconTypes.Warning,
+                    buttons: [t('note.delete2'), t('general.cancel')],
+                    defaultButtonIndex: 0,
+                    cancelButtonIndex: 1,
+                    onClose: (value: number | null) => {
+                      if (value === 0) {
+                        purgeNote(note.storageId, note._id)
+                      }
                     }
-                  }
-                })
+                  })
+                }
               }
             }
-          }
-        ]
-      } else {
-        menuItems = [
-          {
-            type: MenuTypes.Normal,
-            label: t('note.duplicate'),
-            onClick: async () => {
-              createNote(note.storageId, {
-                title: note.title,
-                content: note.content,
-                folderPathname: note.folderPathname,
-                tags: note.tags,
-                bookmarked: false,
-                data: note.data
-              })
-            }
-          },
-          {
-            type: MenuTypes.Normal,
-            label: t('note.delete'),
-            onClick: async () => {
-              if (!note.trashed) {
-                trashNote(note.storageId, note._id)
-              } else {
-                messageBox({
-                  title: t('note.delete2'),
-                  message: t('note.deleteMessage'),
-                  iconType: DialogIconTypes.Warning,
-                  buttons: [t('note.delete2'), t('general.cancel')],
-                  defaultButtonIndex: 0,
-                  cancelButtonIndex: 1,
-                  onClose: (value: number | null) => {
-                    if (value === 0) {
-                      purgeNote(note.storageId, note._id)
-                    }
-                  }
+          ]
+        : [
+            {
+              type: MenuTypes.Normal,
+              label: t('note.duplicate'),
+              onClick: async () => {
+                createNote(note.storageId, {
+                  title: note.title,
+                  content: note.content,
+                  folderPathname: note.folderPathname,
+                  tags: note.tags,
+                  bookmarked: false,
+                  data: note.data
                 })
               }
+            },
+            {
+              type: MenuTypes.Normal,
+              label: t('note.delete'),
+              onClick: async () => {
+                if (!note.trashed) {
+                  trashNote(note.storageId, note._id)
+                } else {
+                  messageBox({
+                    title: t('note.delete2'),
+                    message: t('note.deleteMessage'),
+                    iconType: DialogIconTypes.Warning,
+                    buttons: [t('note.delete2'), t('general.cancel')],
+                    defaultButtonIndex: 0,
+                    cancelButtonIndex: 1,
+                    onClose: (value: number | null) => {
+                      if (value === 0) {
+                        purgeNote(note.storageId, note._id)
+                      }
+                    }
+                  })
+                }
+              }
+            },
+            {
+              type: MenuTypes.Normal,
+              label: note.bookmarked ? t('bookmark.remove') : t('bookmark.add'),
+              onClick: async () => {
+                note.bookmarked = !note.bookmarked
+                updateNote(note.storageId, note._id, note)
+              }
             }
-          },
-          {
-            type: MenuTypes.Normal,
-            label: note.bookmarked ? t('bookmark.remove') : t('bookmark.add'),
-            onClick: async () => {
-              note.bookmarked = !note.bookmarked
-              updateNote(note.storageId, note._id, note)
-            }
-          }
-        ]
-      }
+          ]
 
       popup(event, menuItems)
     },

--- a/src/lib/i18n/enUS.ts
+++ b/src/lib/i18n/enUS.ts
@@ -63,6 +63,7 @@ export default {
     'note.createkeymessage1': 'to create a new note',
     'note.createkeymessage2': 'Select a storage',
     'note.createkeymessage3': 'to create a new note',
+    'note.restore': 'Restore',
 
     //Bookmark
     'bookmark.remove': 'Remove Bookmark',

--- a/src/lib/i18n/esEs.ts
+++ b/src/lib/i18n/esEs.ts
@@ -66,6 +66,7 @@ export default {
     'note.createkeymessage1': 'Para crear una nueva nota',
     'note.createkeymessage2': 'Selecciona un lugar de almacenamiento',
     'note.createkeymessage3': 'Para crear una nota',
+    'note.restore': 'Restore',
 
     //Bookmark
     'bookmark.remove': 'Eliminar marcador',

--- a/src/lib/i18n/ja.ts
+++ b/src/lib/i18n/ja.ts
@@ -63,6 +63,7 @@ export default {
     'note.createkeymessage1': 'ノート作成',
     'note.createkeymessage2': 'ストレージを選択しましょう',
     'note.createkeymessage3': 'ノート作成',
+    'note.restore': '復元',
 
     //Bookmark
     'bookmark.remove': 'ブックマークを削除する',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -62,6 +62,7 @@ export default {
     'note.createkeymessage1': '새 노트 생성',
     'note.createkeymessage2': '저장소 선택',
     'note.createkeymessage3': '새 노트 생성',
+    'note.restore': 'Restore',
 
     //Bookmark
     'bookmark.remove': '북마크 제거',

--- a/src/lib/i18n/ko.ts
+++ b/src/lib/i18n/ko.ts
@@ -62,7 +62,7 @@ export default {
     'note.createkeymessage1': '새 노트 생성',
     'note.createkeymessage2': '저장소 선택',
     'note.createkeymessage3': '새 노트 생성',
-    'note.restore': 'Restore',
+    'note.restore': '복원',
 
     //Bookmark
     'bookmark.remove': '북마크 제거',

--- a/src/lib/i18n/ptBR.ts
+++ b/src/lib/i18n/ptBR.ts
@@ -65,6 +65,7 @@
     'note.createkeymessage1': 'Para criar uma nova nota',
     'note.createkeymessage2': 'Selecionar um armazenamento',
     'note.createkeymessage3': 'Para criar uma nota',
+    'note.restore': 'Restore',
 
     //Bookmark
     'bookmark.remove': 'Remover marcador',

--- a/src/lib/i18n/zhCN.ts
+++ b/src/lib/i18n/zhCN.ts
@@ -62,6 +62,7 @@ export default {
     'note.createkeymessage1': '创建新笔记',
     'note.createkeymessage2': '选择储存',
     'note.createkeymessage3': '创建新笔记',
+    'note.restore': 'Restore',
 
     //Bookmark
     'bookmark.remove': '移除书签',


### PR DESCRIPTION
## Problem
Regardless of whether it has been deleted, the following menu is displayed when select note item.

```
- Duplicate
- Delete
- Bookmark | Remove bookmark
```

But I think `Duplicate` and `Bookmark | Remove bookmark` menu should not be shown when select trashed note.

## Suggestion
When select trashed note, the following menu is desirable
```
- Delete
- Restore
```

`Restore` behaves the same as tapping untrashed icon

## Change
- Add `note.restore`( some language I didn't understand remains `Restore`)
- Show restore and delete menu when `note.trashed` is true(not show duplicate and bookmark menu)

## GIF
![demo](https://user-images.githubusercontent.com/12893657/72262305-03630900-365a-11ea-8064-1e82f7ba73c4.gif)

