### PR TITLE
changes folder for a note from the note's breadcrumbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3090,7 +3090,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -11410,7 +11410,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -14535,7 +14535,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -15639,7 +15639,7 @@
         },
         "readable-stream": {
           "version": "1.0.33",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/src/components/NotePage/NoteDetail/NoteDetail.tsx
+++ b/src/components/NotePage/NoteDetail/NoteDetail.tsx
@@ -484,7 +484,11 @@ export default class NoteDetail extends React.Component<
 
   handleBreadcrumbStorageClick = () => {
     if (this.breadcrumbDropdownRef.current) {
-      this.breadcrumbDropdownRef.current.style.display = 'block'
+      const isHidden =
+        this.breadcrumbDropdownRef.current.style.display === 'none'
+      this.breadcrumbDropdownRef.current.style.display = isHidden
+        ? 'block'
+        : 'none'
     }
   }
 
@@ -528,6 +532,8 @@ export default class NoteDetail extends React.Component<
       />
     )
 
+    const currentStorageIds = Object.keys(storageMap || {})
+
     return (
       <StyledNoteDetailContainer
         onDragEnd={(event: React.DragEvent) => {
@@ -553,21 +559,27 @@ export default class NoteDetail extends React.Component<
                 >
                   <span className='trigger'>{noteStorageName}</span>
                   <div ref={this.breadcrumbDropdownRef} className='dropdown'>
-                    {Object.keys(storageMap || {}).map((storageId: any) => {
-                      // @ts-ignore
-                      const storageName = storageMap[storageId].name
-                      return (
-                        <div
-                          key={storageId}
-                          className='storage'
-                          onClick={this.handleBreadcrumbStorageChange(
-                            storageId
-                          )}
-                        >
-                          {storageName}
-                        </div>
-                      )
-                    })}
+                    {currentStorageIds.map(
+                      (storageId: keyof ObjectMap<NoteStorage>) => {
+                        if (storageMap) {
+                          const storage = storageMap[storageId]
+                          if (storage) {
+                            return (
+                              <div
+                                key={storageId}
+                                className='storage'
+                                onClick={this.handleBreadcrumbStorageChange(
+                                  String(storageId)
+                                )}
+                              >
+                                {storage.name}
+                              </div>
+                            )
+                          }
+                        }
+                        return null
+                      }
+                    )}
                   </div>
                 </div>
                 {this.props.breadCrumbs != null && (

--- a/src/components/NotePage/NotePage.tsx
+++ b/src/components/NotePage/NotePage.tsx
@@ -46,8 +46,10 @@ export default () => {
     updateNote,
     trashNote,
     untrashNote,
+    moveNoteToOtherStorage,
     addAttachments
   } = useDb()
+
   const routeParams = useRouteParams() as (
     | StorageAllNotes
     | StorageNotesRouteParams
@@ -360,9 +362,11 @@ export default () => {
             untrashNote={untrashNote}
             addAttachments={addAttachments}
             purgeNote={showPurgeNoteDialog}
+            moveNoteToOtherStorage={moveNoteToOtherStorage}
             viewMode={generalStatus.noteViewMode}
             toggleViewMode={toggleViewMode}
             push={push}
+            storageMap={storageMap}
             breadCrumbs={breadCrumbs}
           />
         )


### PR DESCRIPTION
fixes #347

before this pull request when we click on the storage name, it changes the mode to "All Notes" but they can already do that themselves by clicking that on the left side. so this pull request proposes a useful alternative to replace the note's storage from a dropdown menu instead

![issue347pullrequest](https://user-images.githubusercontent.com/20717348/74462841-b97e6600-4e45-11ea-867f-15e69c4c50b5.gif)
