### PR TITLE
Optional front-matter for markdown export

### DIFF
--- a/src/components/PreferencesModal/ExportTab.tsx
+++ b/src/components/PreferencesModal/ExportTab.tsx
@@ -1,12 +1,39 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { usePreferences } from '../../lib/preferences'
 import { useTranslation } from 'react-i18next'
+import { Section, SectionHeader, SectionControl } from './styled'
+import { FormCheckItem } from '../atoms/form'
 
 export default () => {
   const { t } = useTranslation()
+  const { preferences, setPreferences } = usePreferences()
+
+  const toggleFrontMatterExport: React.ChangeEventHandler<
+    HTMLInputElement
+  > = useCallback(
+    event => {
+      setPreferences({
+        'export.markdown.includeFrontMatter': event.target.checked
+      })
+    },
+    [setPreferences]
+  )
+
   return (
-    <Section>
-      <SectionHeader>{t('preferences.export')}</SectionHeader>
-    </Section>
+    <div>
+      <Section>
+        <SectionHeader>Include front-matters in markdown export</SectionHeader>
+        <SectionControl>
+          <FormCheckItem
+            id='checkbox-include-front-matters'
+            type='checkbox'
+            checked={preferences['export.markdown.includeFrontMatter']}
+            onChange={toggleFrontMatterExport}
+          >
+            Include front-matters in markdown export
+          </FormCheckItem>
+        </SectionControl>
+      </Section>
+    </div>
   )
 }

--- a/src/components/PreferencesModal/ExportTab.tsx
+++ b/src/components/PreferencesModal/ExportTab.tsx
@@ -22,7 +22,7 @@ export default () => {
   return (
     <div>
       <Section>
-        <SectionHeader>Include front-matters in markdown export</SectionHeader>
+        <SectionHeader>{t('preferences.exportFrontMatter')}</SectionHeader>
         <SectionControl>
           <FormCheckItem
             id='checkbox-include-front-matters'
@@ -30,7 +30,7 @@ export default () => {
             checked={preferences['export.markdown.includeFrontMatter']}
             onChange={toggleFrontMatterExport}
           >
-            Include front-matters in markdown export
+            {t('preferences.exportFrontMatter')}
           </FormCheckItem>
         </SectionControl>
       </Section>

--- a/src/components/PreferencesModal/ExportTab.tsx
+++ b/src/components/PreferencesModal/ExportTab.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { usePreferences } from '../../lib/preferences'
+import { useTranslation } from 'react-i18next'
+
+export default () => {
+  const { t } = useTranslation()
+  return (
+    <Section>
+      <SectionHeader>{t('preferences.export')}</SectionHeader>
+    </Section>
+  )
+}

--- a/src/components/PreferencesModal/PreferencesModal.tsx
+++ b/src/components/PreferencesModal/PreferencesModal.tsx
@@ -9,9 +9,10 @@ import MarkdownTab from './MarkdownTab'
 import AboutTab from './AboutTab'
 import BillingTab from './BillingTab'
 import ImportTab from './ImportTab'
+import ExportTab from './ExportTab'
 import {
   backgroundColor,
-  closeIconColor,
+  closeIconColor
 } from '../../lib/styled/styleFunctions'
 import { IconClose } from '../icons'
 import { useTranslation } from 'react-i18next'
@@ -84,6 +85,8 @@ const PreferencesModal = () => {
         return <BillingTab />
       case 'import':
         return <ImportTab />
+      case 'export':
+        return <ExportTab />
       case 'general':
       default:
         return <GeneralTab />
@@ -138,6 +141,12 @@ const PreferencesModal = () => {
           label='Import'
           tab='import'
           active={tab === 'import'}
+          setTab={setTab}
+        />
+        <TabButton
+          label='Export'
+          tab='export'
+          active={tab === 'export'}
           setTab={setTab}
         />
       </TabNav>

--- a/src/components/PreferencesModal/styled.tsx
+++ b/src/components/PreferencesModal/styled.tsx
@@ -6,7 +6,7 @@ import {
   inputStyle,
   tableStyle,
   disabledUiTextColor,
-  PrimaryTextColor,
+  PrimaryTextColor
 } from '../../lib/styled/styleFunctions'
 
 export const Section = styled.section`

--- a/src/components/atoms/ToolbarExportButton.tsx
+++ b/src/components/atoms/ToolbarExportButton.tsx
@@ -6,6 +6,7 @@ import { NoteDoc } from '../../lib/db/types'
 import {
   exportNoteAsHtmlFile,
   exportNoteAsMarkdownFile,
+  MarkdownExportOptions
 } from '../../lib/exports'
 import { usePreferences } from '../../lib/preferences'
 import { usePreviewStyle } from '../../lib/preview'
@@ -45,13 +46,13 @@ const ToolbarExportButton = ({ className, note }: ToolbarExportButtonProps) => {
           type: MenuTypes.Normal,
           label: 'HTML export',
           onClick: async () =>
-            await exportNoteAsHtmlFile(note, preferences, previewStyle),
+            await exportNoteAsHtmlFile(note, preferences, previewStyle)
         },
         {
           type: MenuTypes.Normal,
           label: 'Markdown export',
-          onClick: async () => await exportNoteAsMarkdownFile(note),
-        },
+          onClick: async () => await exportNoteAsMarkdownFile(note, preferences)
+        }
       ])
     },
     [popup, note, preferences, previewStyle]

--- a/src/lib/exports.ts
+++ b/src/lib/exports.ts
@@ -16,7 +16,7 @@ import { NoteDoc } from './db/types'
 import { Preferences } from './preferences'
 
 const sanitizeSchema = mergeDeepRight(gh, {
-  attributes: { '*': ['className'] },
+  attributes: { '*': ['className'] }
 })
 
 export const exportNoteAsHtmlFile = async (
@@ -30,7 +30,7 @@ export const exportNoteAsHtmlFile = async (
     .use(remarkRehype, { allowDangerousHTML: false })
     .use(rehypeCodeMirror, {
       ignoreMissing: true,
-      theme: preferences['markdown.codeBlockTheme'],
+      theme: preferences['markdown.codeBlockTheme']
     })
     .use(rehypeRaw)
     .use(rehypeSanitize, sanitizeSchema)
@@ -38,7 +38,7 @@ export const exportNoteAsHtmlFile = async (
       title: note.title,
       style: previewStyle,
       css: 'https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css',
-      meta: { keywords: note.tags.join() },
+      meta: { keywords: note.tags.join() }
     })
     .use(rehypeStringify)
     .use(rehypeKatex)
@@ -59,7 +59,8 @@ export const exportNoteAsHtmlFile = async (
 }
 
 export const exportNoteAsMarkdownFile = async (
-  note: NoteDoc
+  note: NoteDoc,
+  preferences: Preferences
 ): Promise<void> => {
   await unified()
     .use(remarkParse)
@@ -70,14 +71,17 @@ export const exportNoteAsMarkdownFile = async (
         console.error(err)
         return
       }
-      downloadString(
-        [
+      let exportContent = [file.toString()]
+      if (preferences['export.markdown.includeFrontMatter']) {
+        exportContent = [
           '---',
           `title: "${note.title}"`,
           `tags: "${note.tags.join()}"`,
-          '---',
-          file.toString(),
-        ].join('\n'),
+          '---'
+        ].concat(exportContent)
+      }
+      downloadString(
+        exportContent.join('\n'),
         `${note.title.toLowerCase().replace(/\s+/g, '-')}.md`,
         'text/markdown'
       )

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -56,6 +56,9 @@ export interface Preferences {
   // Markdown
   'markdown.previewStyle': string
   'markdown.codeBlockTheme': string
+
+  // Export
+  'export.markdown.includeFrontMatter': boolean
 }
 
 function loadPreferences() {
@@ -98,6 +101,7 @@ const basePreferences: Preferences = {
   // Markdown
   'markdown.previewStyle': 'default',
   'markdown.codeBlockTheme': 'default',
+  'export.markdown.includeFrontMatter': true
 }
 
 function usePreferencesStore() {
@@ -111,7 +115,7 @@ function usePreferencesStore() {
   const mergedPreferences = useMemo(() => {
     return {
       ...basePreferences,
-      ...preferences,
+      ...preferences
     }
   }, [preferences])
 
@@ -135,13 +139,13 @@ function usePreferencesStore() {
     setClosed,
     toggleClosed,
     preferences: mergedPreferences,
-    setPreferences,
+    setPreferences
   }
 }
 
 export const {
   StoreProvider: PreferencesProvider,
-  useStore: usePreferences,
+  useStore: usePreferences
 } = createStoreContext(usePreferencesStore, 'preferences')
 
 export function useFirstUser() {

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -159,5 +159,9 @@ export default {
     'preferences.importFlow4': '4. Upload!',
     'preferences.importRemove': 'entfernen',
     'preferences.importUpload': 'Upload',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter':
+      'Front-Materie in den Markdown-Export einbeziehen'
+  }
 }

--- a/src/locales/enUS.ts
+++ b/src/locales/enUS.ts
@@ -159,6 +159,6 @@ export default {
     'preferences.importUpload': 'Upload',
 
     // Preferences ExportTab
-    'preferences.export': 'Export'
+    'preferences.exportFrontMatter': 'Include front-matters in Markdown export'
   }
 }

--- a/src/locales/enUS.ts
+++ b/src/locales/enUS.ts
@@ -157,5 +157,8 @@ export default {
     'preferences.importFlow4': '4. Upload!',
     'preferences.importRemove': 'remove',
     'preferences.importUpload': 'Upload',
-  },
+
+    // Preferences ExportTab
+    'preferences.export': 'Export'
+  }
 }

--- a/src/locales/esES.ts
+++ b/src/locales/esES.ts
@@ -163,5 +163,9 @@ export default {
     'preferences.importFlow4': '4. Cargar!',
     'preferences.importRemove': 'Eliminar',
     'preferences.importUpload': 'Subir',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter':
+      'Incluir front-matter en la exportación Markdown'
+  }
 }

--- a/src/locales/frFR.ts
+++ b/src/locales/frFR.ts
@@ -164,5 +164,9 @@ export default {
     'preferences.importFlow4': '4. Télécharger!',
     'preferences.importRemove': 'supprimer',
     'preferences.importUpload': 'Télécharger',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter':
+      "Inclure l'avant-propos dans l'exportation Markdown"
+  }
 }

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -159,5 +159,9 @@ export default {
     'preferences.importFlow4': '4. アップロード',
     'preferences.importRemove': '削除',
     'preferences.importUpload': 'アップロード',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter':
+      'Markdownエクスポートにフロントマターを含める'
+  }
 }

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -155,5 +155,8 @@ export default {
     'preferences.importFlow4': '4. 업로드!',
     'preferences.importRemove': '삭제',
     'preferences.importUpload': '업로드',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter': 'Markdown 내보내기에 선행 사항 포함'
+  }
 }

--- a/src/locales/ukUA.ts
+++ b/src/locales/ukUA.ts
@@ -157,5 +157,9 @@ export default {
     'preferences.importFlow4': '4. Upload!',
     'preferences.importRemove': 'Видалити',
     'preferences.importUpload': 'Завантажити',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter':
+      'Включіть експортну інформацію в експорті Markdown'
+  }
 }

--- a/src/locales/zhCN.ts
+++ b/src/locales/zhCN.ts
@@ -152,5 +152,8 @@ export default {
     'preferences.importFlow4': '4. 上传!',
     'preferences.importRemove': '移除',
     'preferences.importUpload': '上传',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter': '在Markdown导出中包括前题'
+  }
 }

--- a/src/locales/zhHK.ts
+++ b/src/locales/zhHK.ts
@@ -153,5 +153,8 @@ export default {
     'preferences.importFlow4': '4. 上傳!',
     'preferences.importRemove': '移除',
     'preferences.importUpload': '上傳',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter': '在標記導出中包括前物質'
+  }
 }

--- a/src/locales/zhTW.ts
+++ b/src/locales/zhTW.ts
@@ -152,5 +152,8 @@ export default {
     'preferences.importFlow4': '4. 上傳!',
     'preferences.importRemove': '移除',
     'preferences.importUpload': '上傳',
-  },
+
+    // Preferences ExportTab
+    'preferences.exportFrontMatter': '在Markdown导出中包括前题'
+  }
 }


### PR DESCRIPTION
This PR add support for optional front-matter for markdown export
Issue fixed: https://github.com/BoostIO/BoostNote.next/issues/346


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#346: Have an option to export note without the front-matter](https://issuehunt.io/repos/74213528/issues/346)
---
</details>
<!-- /Issuehunt content-->