### PR TITLE
General overhaul of the de-localization

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -45,7 +45,7 @@ export default {
     //Tag
     'tag.tag': 'Tag',
     'tag.remove': 'Tag löschen',
-    'tag.removeMessage': 'Der Tag wird von allen Notizen entfernt.',
+    'tag.removeMessage': 'Das Tag wird von allen Notizen entfernt.',
 
     //Note
     'note.duplicate': 'Duplizieren',
@@ -88,7 +88,7 @@ export default {
 
     //Billing
     'billing.billing': 'Billing',
-    'billing.message': 'Bitte melde dich an, um deinen Plan zu ugpraden.',
+    'billing.message': 'Bitte melde dich an, um deinen Plan zu erweitern.',
     'billing.basic': 'Basic',
     'billing.current': 'Aktuell',
     'billing.premium': 'Premium',
@@ -144,7 +144,7 @@ export default {
 
     // Preferences MarkdownTab
     'preferences.previewStyle': 'Vorschau Style',
-    'preferences.markdownCodeBlockTheme': 'Code Block Theme',
+    'preferences.markdownCodeBlockTheme': 'Code Block Design',
     'preferences.defaultTheme': 'Verwende Standard-Design',
     'preferences.markdownPreview': 'Markdown Vorschau',
 

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -20,7 +20,7 @@ export default {
     'storage.rename': 'Speicherort umbenennen',
     'storage.renameMessage': 'Name des Speicherorts ändern',
     'storage.remove': 'Speicherort entfernen',
-    'storage.removeMessage': 'Speicherort wird gelöscht',
+    'storage.removeMessage': 'Verknüpfung des Speicherorts wird entfernt
     'storage.delete': 'Speicherort löschen',
     'storage.move': 'Speicherort verschieben',
     'storage.moveTitle': 'Speicherort wird verschoben',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -20,7 +20,7 @@ export default {
     'storage.rename': 'Speicherort umbenennen',
     'storage.renameMessage': 'Name des Speicherorts ändern',
     'storage.remove': 'Speicherort entfernen',
-    'storage.removeMessage': 'Verknüpfung des Speicherorts wird entfernt
+    'storage.removeMessage': 'Verknüpfung des Speicherorts wird entfernt',
     'storage.delete': 'Speicherort löschen',
     'storage.move': 'Speicherort verschieben',
     'storage.moveTitle': 'Speicherort wird verschoben',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -37,7 +37,7 @@ export default {
     'folder.create': 'Neuer Ordner',
     'folder.rename': 'Ordner umbenennen',
     'folder.renameMessage':
-      'Gib den neuen Ordnernamen an. Notizen und Pfade von Unterordnern werden aktualisiert.',
+      'Gib den neuen Ordnernamen an. Notizen und Pfade von Unterordnern werden automatisch aktualisiert.',
     'folder.renameErrorMessage': 'Ordner konnte nicht umbenannt werden',
     'folder.remove': 'Ordner löschen',
     'folder.removeMessage': 'Alle Notizen und Unterordner werden gelöscht.',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -10,42 +10,42 @@ export default {
     'general.signOut': 'Abmelden',
     'general.save': 'Speichern',
     'general.default': 'Standard',
-    'general.networkError': 'Netzwerk-Fehler',
+    'general.networkError': 'Netzwerkfehler',
 
     // Storage
-    'storage.name': 'Speicherort Name',
+    'storage.name': 'Name des Speicherorts',
     'storage.noStorage': 'Kein Speicherort',
     'storage.create': 'Speicherort erstellen',
     'storage.edit': 'Speicherort ändern',
     'storage.rename': 'Speicherort umbenennen',
-    'storage.renameMessage': 'Name für Speicherort ändern',
+    'storage.renameMessage': 'Name des Speicherorts ändern',
     'storage.remove': 'Speicherort entfernen',
-    'storage.removeMessage': 'Speicherort wird von App entknüpft',
+    'storage.removeMessage': 'Speicherort wird gelöscht',
     'storage.delete': 'Speicherort löschen',
-    'storage.move': 'Notiz verschieben',
-    'storage.moveTitle': 'Notiz in anderen Speicherort verschieben',
+    'storage.move': 'Speicherort verschieben',
+    'storage.moveTitle': 'Speicherort wird verschoben',
     'storage.moveMessage':
-      'Es wird versucht eine Notiz in einen anderen Speicherort zu verschieben.',
-    'storage.copy': 'Notiz kopieren',
+      'Es wird versucht, den Speicherort zu verschieben.',
+    'storage.copy': 'Speicherort kopieren',
     'storage.typeLocal': 'Lokal',
     'storage.typeCloud': 'Cloud',
     'storage.needSignIn':
-      'Du musst dich anmelden um einen Cloud-Speicher zu erstellen.',
+      'Du musst dich anmelden, um einen Cloud-Speicher zu erstellen.',
     'storage.syncDate': 'Zuletzt synchronisiert am',
 
     //Folder
     'folder.create': 'Neuer Ordner',
     'folder.rename': 'Ordner umbenennen',
     'folder.renameMessage':
-      'Gib den neuen Ordnernamen an, jede Notiz und Unterordner-Pfad wird aktualisiert.',
+      'Gib den neuen Ordnernamen an. Notizen und Pfade von Unterordnern werden aktualisiert.',
     'folder.renameErrorMessage': 'Ordner konnte nicht umbenannt werden',
     'folder.remove': 'Ordner löschen',
     'folder.removeMessage': 'Alle Notizen und Unterordner werden gelöscht.',
 
     //Tag
-    'tag.tag': 'Etikett',
-    'tag.remove': 'Etikett löschen',
-    'tag.removeMessage': 'Das Etikett wird von allen Notizen entfernt.',
+    'tag.tag': 'Tag',
+    'tag.remove': 'Tag löschen',
+    'tag.removeMessage': 'Der Tag wird von allen Notizen entfernt.',
 
     //Note
     'note.duplicate': 'Duplizieren',
@@ -73,13 +73,13 @@ export default {
     //About
     'about.about': 'Über',
     'about.boostnoteDescription':
-      'Ein quelloffenes Notiz-Programm geschaffen für Programmierer wie dir.',
+      'Ein quelloffenes Notiz-Programm, geschaffen für Programmierer wie dich.',
     'about.website': 'Offizielle Webseite',
-    'about.boostWiki': 'Boost Note für Team',
+    'about.boostWiki': 'Boost Note für Teams',
     'about.platform': 'Cross-platform',
     'about.community': 'Community',
     'about.github': 'GitHub Repository',
-    'about.bounty': 'Bounty on IssueHunt',
+    'about.bounty': 'Bounty auf IssueHunt',
     'about.blog': 'Blog',
     'about.slack': 'Slack Gruppe',
     'about.twitter': 'Twitter Account',
@@ -88,7 +88,7 @@ export default {
 
     //Billing
     'billing.billing': 'Billing',
-    'billing.message': 'Bitte melde dich an um deinen Plan zu ugpraden.',
+    'billing.message': 'Bitte melde dich an, um deinen Plan zu ugpraden.',
     'billing.basic': 'Basic',
     'billing.current': 'Aktuell',
     'billing.premium': 'Premium',
@@ -99,7 +99,7 @@ export default {
     'billing.sync': 'Mehrere Geräte synchronisieren',
     'billing.local': 'Lokaler Speicher',
     'billing.cloud': 'Cloud Speicher',
-    'billing.storageSize': 'Cloud Speicher Größe',
+    'billing.storageSize': 'Cloud Speichergröße',
     'billing.addStorageDescription':
       '* Wenn du mehr Cloud-Speicher brauchst, zahlst du 5$ (USD) für jede zusätzliche 5GB. Drücke auf den "Extra Speicher hinzufügen"-Knopf unten.',
     'billing.addStorage': 'Extra Speicher hinzufügen',
@@ -112,7 +112,7 @@ export default {
     'preferences.addAccount': 'Anmelden',
     'preferences.loginWorking': 'Wird angemeldet...',
     'preferences.interfaceLanguage': 'Oberflächen Sprache',
-    'preferences.applicationTheme': 'Anwendungs-Theme',
+    'preferences.applicationTheme': 'Anwendungs-Design',
     'preferences.auto': 'Auto',
     'preferences.light': 'Hell',
     'preferences.dark': 'Dunkel',
@@ -122,17 +122,17 @@ export default {
     'preferences.dateUpdated': 'Datum aktualisiert',
     'preferences.dateCreated': 'Datum erstellt',
     'preferences.title': 'Titel',
-    'preferences.analytics': 'Analytik',
+    'preferences.analytics': 'Analytics',
     'preferences.analyticsDescription1':
-      'Boostnote sammelt anonyme Daten um das Nutzererlebnis zu verbessern, und es wird streng darauf geachtet keine persönlichen Informationen wie die Inhalte der Notizen zu senden. Um zu sehen wie das läuft, besuche unsere Github Seite.',
+      'Boostnote sammelt anonyme Daten, um das Nutzererlebnis zu verbessern. Es wird streng darauf geachtet keine persönlichen Informationen wie die Inhalte der Notizen zu senden. Um zu sehen wie das läuft, besuche unsere Github Seite.',
     'preferences.analyticsDescription2':
-      'Du kannst wählen diese Option zu aktivieren oder deaktivieren.',
+      'Du kannst diese Option aktivieren oder deaktivieren.',
     'preferences.analyticsLabel':
-      'Analytik aktivieren um dich an der Verbesserung von Boostnote zu beteiligen.',
-    'preferences.displayTutorialsLabel': 'Tutorials and FAQ',
+      'Analytics aktivieren, um dich an der Verbesserung von Boostnote zu beteiligen.',
+    'preferences.displayTutorialsLabel': 'Tutorials und FAQ',
 
     // Preferences EditorTab
-    'preferences.editorTheme': 'Editor Theme',
+    'preferences.editorTheme': 'Editor Design',
     'preferences.editorFontSize': 'Editor Schriftgröße',
     'preferences.editorFontFamily': 'Editor Schriftart',
     'preferences.editorIndentType': 'Editor Einrückungs-Typ',
@@ -145,19 +145,19 @@ export default {
     // Preferences MarkdownTab
     'preferences.previewStyle': 'Vorschau Style',
     'preferences.markdownCodeBlockTheme': 'Code Block Theme',
-    'preferences.defaultTheme': 'Verwende standard Style',
+    'preferences.defaultTheme': 'Verwende Standard-Design',
     'preferences.markdownPreview': 'Markdown Vorschau',
 
     // Preferences ImportTab
     'preferences.import': 'Importieren',
-    'preferences.description': 'Importiert .cson files vom alten Boostnote.',
+    'preferences.description': 'Importiert .cson Dateien vom alten Boostnote Ordner.',
     'preferences.importFlow1':
       '1. Öffne den alten Boostnote Ordner auf deinem PC.',
     'preferences.importFlow2': '2. Ziehe die .cson Dateien in das Feld unten.',
     'preferences.importFlow3':
-      '3. Wähle den Speicher und den Ordner in die du die Dateien verschieben möchtest.',
+      '3. Wähle den Speicher und den Ordner, in welchen du die Dateien verschieben möchtest.',
     'preferences.importFlow4': '4. Upload!',
-    'preferences.importRemove': 'entfernen',
+    'preferences.importRemove': 'Entfernen',
     'preferences.importUpload': 'Upload',
   },
 }


### PR DESCRIPTION
General overhaul of the de-localization.

I feel like ```Speicherort``` as the main translation for ```storage``` is generally correct but quite unusual. You should think about maybe changing it to something like ```Notizbuch = Notebook``` on many occasions. If you wish to implement that feel free to ask me to translate it.

'note.date': currently it says e.g. ```38 minutes her``` but it should either be ```38 Minuten her``` or ```vor 38 Minuten```. IMO the second one is better, but I think more code adjustment is necessary somewhere else to rephrase the wording.

Btw: where can I translate other things like e.g. ```Storage Settings``` or ```Remove Storage``` when you edit your storage?