### PR TITLE
RPM build target | #441

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
       "icon": "static/icon.icns",
       "target": [
         "deb",
+        "rpm",
         "AppImage"
       ]
     },


### PR DESCRIPTION
**Requires rpm build essentials**

- Addresses Issue #441 

The project's `electron-builder` build script are based on the current architecture/OS of the user, so it probably needs redhat-based machines (ex. Fedora, CentOS, etc.) to achieve `.rpm` builds.

-----

I also **suggest** seperating `electron-builder` configurations to its own dedicated file: `electron-builder.yml` to avoid the cluttering of `package.json`.

> `json`, `json5`, `toml` or `js` (exported configuration or function that produces configuration) formats also supported.
