### PR TITLE
Limit electron app window size

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -20,6 +20,8 @@ function createMainWindow() {
     webPreferences: { nodeIntegration: true },
     width: 1200,
     height: 800,
+    minWidth: 960,
+    minHeight: 630,
   }
   if (process.platform === 'darwin') {
     windowOptions.titleBarStyle = 'hiddenInset'


### PR DESCRIPTION
Limits electron app windows size enough to see the panes.

> Remake of #459 after accidental rebase & push on wrong branch.