### PR TITLE
Fix storage edit page not scrolling because of height not set on cont…

### DIFF
--- a/src/components/atoms/PageContainer.tsx
+++ b/src/components/atoms/PageContainer.tsx
@@ -4,6 +4,7 @@ const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  height: 100%;
 `
 
 export default PageContainer


### PR DESCRIPTION
Fix storage edit page not scrolling because of height not set on container.

I tried managing it multiple ways, one being adding container above "ScrollableComponent" but this either don't work or requires a lot of css to deal with it (for example similar to TabComponent, Container, but with some top offset so it skips movable header)

Maybe this could also be fixed by having general 100% height on some root container, instead of page container. 

Should I run some tests, it's a small change, but maybe this will break some other components using the PageContainer style?
