### PR TITLE
added copy button for codeblock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4100,6 +4100,16 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -4962,6 +4972,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -7698,6 +7713,14 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -13439,6 +13462,11 @@
       "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.2.tgz",
       "integrity": "sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ=="
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -14888,6 +14916,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-invariant": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@types/pouchdb-replication": "^6.4.2",
     "aws-amplify": "^1.2.4",
     "classcat": "^4.0.2",
+    "clipboard": "^2.0.6",
     "codemirror": "^5.49.0",
     "coffeescript": "^2.4.1",
     "copy-webpack-plugin": "^5.0.4",

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -21,6 +21,7 @@ import { Attachment, ObjectMap } from '../../lib/db/types'
 import 'katex/dist/katex.min.css'
 import MarkdownCheckbox from './markdown/MarkdownCheckbox'
 import AttachmentImage from './markdown/AttachmentImage'
+import CodeblockCopyButton from './markdown/CodeblockCopyButton'
 
 const schema = mergeDeepRight(gh, {
   attributes: {
@@ -111,6 +112,8 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
         }
       }
 
+      // copy button
+      cmResult.push(h('span', { className: 'code-copy-btn' }, rawContent))
       node.children = cmResult
     }
 
@@ -225,6 +228,13 @@ const MarkdownPreviewer = ({
                 updateContent={updateContent}
               />
             )
+          },
+          span: (props: React.HTMLProps<HTMLSpanElement>) => {
+            const { className, children } = props
+            if (className == 'code-copy-btn') {
+              return <CodeblockCopyButton code={children[0]} />
+            }
+            return <span {...props} />
           },
         },
       })

--- a/src/components/atoms/markdown/CodeblockCopyButton.tsx
+++ b/src/components/atoms/markdown/CodeblockCopyButton.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from 'react'
+import styled from '../../../lib/styled'
+import Icon from '../Icon'
+import { mdiContentCopy } from '@mdi/js'
+import Clipboard from 'clipboard'
+
+const StyledCopyButton = styled.button`
+  color: currentColor;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  top: 10px;
+  right: 10px;
+  position: absolute;
+
+  svg {
+    margin-top: 2px;
+    vertical-align: top;
+  }
+`
+
+interface CodeblockCopyButtonProps {
+  code: string
+}
+
+const CodeblockCopyButton = ({ code }: CodeblockCopyButtonProps) => {
+  const buttonRef = useRef(null)
+  useEffect(() => {
+    new Clipboard(buttonRef.current)
+  }, [])
+  return (
+    <StyledCopyButton data-clipboard-text={code} ref={buttonRef}>
+      <Icon path={mdiContentCopy} />
+    </StyledCopyButton>
+  )
+}
+
+export default CodeblockCopyButton


### PR DESCRIPTION
This added support for copy button for markdown codeblock

Fixed https://github.com/BoostIO/BoostNote.next/issues/315

![ss](https://user-images.githubusercontent.com/12984316/86917191-ca26d400-c178-11ea-8f4b-75b3de8d2ce0.gif)
