### PR TITLE
added line number support for codeblock

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -281,11 +281,13 @@ const MarkdownPreviewer = ({
       const linenumbers = [...code.querySelectorAll('.CodeMirror-linenumber')]
       const linenumberGutter = code.querySelector('.CodeMirror-linenumbers')
       const lastLinenumber = linenumbers[linenumbers.length - 1]
-      const linenumberWidth = lastLinenumber.offsetWidth
-      for (const linenumber of linenumbers) {
-        linenumber.style.width = `${linenumberWidth}px`
+      if (lastLinenumber && linenumberGutter) {
+        const linenumberWidth = lastLinenumber.offsetWidth
+        for (const linenumber of linenumbers) {
+          linenumber.style.width = `${linenumberWidth}px`
+        }
+        linenumberGutter.style.width = `${linenumberWidth}px`
       }
-      linenumberGutter.style.width = `${linenumberWidth}px`
     }
   }, [markdownProcessor])
 
@@ -324,6 +326,7 @@ const MarkdownPreviewer = ({
       .CodeMirror-linenumber {
         display: inline-block;
         min-width: 15px;
+        user-select: none;
       }
       .CodeMirror-linecontent {
         padding-left: 7px;


### PR DESCRIPTION
Added support for line number in code block. This probably not the best way to do it since you have to reset the width and update it every render. Suggestion for improvement are welcome!

![image](https://user-images.githubusercontent.com/12984316/86929272-c64f7d80-c189-11ea-8496-41f384c0e035.png)

![image](https://user-images.githubusercontent.com/12984316/86929348-d9624d80-c189-11ea-87f4-4a1a2342ba35.png)

Fixed: https://github.com/BoostIO/BoostNote.next/issues/315