### PR TITLE
fixed ctrl + a on markdown previewer

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,11 +52,23 @@ const App = () => {
   const { toggleClosed, preferences } = usePreferences()
   const keyboardHandler = useMemo(() => {
     return (event: KeyboardEvent) => {
+      console.log(event)
       switch (event.key) {
         case ',':
           if (isWithGeneralCtrlKey(event)) {
             toggleClosed()
           }
+          break
+        case 'a':
+          if (isWithGeneralCtrlKey(event)) {
+            if (event.target.classList.contains('MarkdownPreviewer')) {
+              event.preventDefault()
+              const range = document.createRange()
+              range.selectNode(event.target)
+              window.getSelection().addRange(range)
+            }
+          }
+          break
       }
     }
   }, [toggleClosed])

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,7 +52,6 @@ const App = () => {
   const { toggleClosed, preferences } = usePreferences()
   const keyboardHandler = useMemo(() => {
     return (event: KeyboardEvent) => {
-      console.log(event)
       switch (event.key) {
         case ',':
           if (isWithGeneralCtrlKey(event)) {

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -275,7 +275,7 @@ const MarkdownPreviewer = ({
   }, [style])
 
   return (
-    <StyledContainer className='MarkdownPreviewer'>
+    <StyledContainer className='MarkdownPreviewer' tabIndex='0'>
       <div className={cc([theme])}>
         {rendering && 'rendering...'}
         {renderedContent}

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -1,15 +1,10 @@
 import { useEffect } from 'react'
 import { osName } from './platform'
-import isElectron from 'is-electron'
 
 export const useGlobalKeyDownHandler = (
   handler: (event: KeyboardEvent) => void
 ) => {
   return useEffect(() => {
-    if (!isElectron()) {
-      return
-    }
-
     window.addEventListener('keydown', handler)
     return () => {
       window.removeEventListener('keydown', handler)


### PR DESCRIPTION
This PR fixed the unwanted select all when the markdown previewer is in focus.

Fixed: https://github.com/BoostIO/BoostNote.next/issues/531

This also allow global key listener to be run on all platform. if there's a reason why this is a bad thing to do, please tell me.