### PR TITLE
Update Slack invite link

### DIFF
--- a/src/components/PreferencesModal/AboutTab.tsx
+++ b/src/components/PreferencesModal/AboutTab.tsx
@@ -193,7 +193,7 @@ const AboutTab = () => {
               </ul>
               <ul>
                 <li>
-                  <PrimaryLink href='https://boostnote-group.slack.com/join/shared_invite/enQtMzkxOTk4ODkyNzc0LWQxZTQwNjBlMDI4YjkyYjg2MTRiZGJhNzA1YjQ5ODA5M2M0M2NlMjI5YjhiYWQzNzgzYmU0MDMwOTlmZmZmMGE'>
+                  <PrimaryLink href='https://join.slack.com/t/boostnote-group/shared_invite/zt-cun7pas3-WwkaezxHBB1lCbUHrwQLXw'>
                     {t('about.slack')}
                   </PrimaryLink>
                 </li>


### PR DESCRIPTION
This new link matches the one used on the homepage.