### PR TITLE
UI: Adjusted Colors

### DIFF
--- a/src/components/atoms/TagNavigatorListItem.tsx
+++ b/src/components/atoms/TagNavigatorListItem.tsx
@@ -10,7 +10,7 @@ const TagItem = styled.li`
   margin-right: 5px;
   height: 24px;
   ${flexCenter}
-  background-color: #404040;
+  background-color: ${({ theme }) => theme.secondaryBackgroundColor};
   border-radius: 12px;
 `
 
@@ -21,14 +21,6 @@ const TagItemAnchor = styled.button`
   padding-left: 0.75em;
   text-decoration: none;
   color: ${({ theme }) => theme.textColor};
-  &:hover {
-    color: ${({ theme }) => theme.navButtonHoverColor};
-  }
-
-  &:active,
-  &.active {
-    color: ${({ theme }) => theme.navButtonActiveColor};
-  }
 `
 
 const TagRemoveButton = styled.button`
@@ -37,15 +29,7 @@ const TagRemoveButton = styled.button`
   padding: 0 0.25em;
   border: none;
   transition: color 200ms ease-in-out;
-  color: ${({ theme }) => theme.navButtonColor};
-  &:hover {
-    color: ${({ theme }) => theme.navButtonHoverColor};
-  }
-
-  &:active,
-  &.active {
-    color: ${({ theme }) => theme.navButtonActiveColor};
-  }
+  color: ${({ theme }) => theme.textColor};
   width: 24px;
   height: 24px;
   ${flexCenter}

--- a/src/components/atoms/TagNavigatorNewTagPopup.tsx
+++ b/src/components/atoms/TagNavigatorNewTagPopup.tsx
@@ -14,6 +14,7 @@ import {
   uiTextColor,
   activeBackgroundColor,
   textOverflow,
+  inputStyle,
 } from '../../lib/styled/styleFunctions'
 import styled from '../../lib/styled'
 import { useEffectOnce } from 'react-use'
@@ -35,6 +36,7 @@ const Container = styled.div`
 `
 
 const TagNameInput = styled.input`
+  ${inputStyle}
   width: 100%;
   height: 30px;
   padding: 0 0.25em;

--- a/src/components/atoms/TopbarSwitchSelector.tsx
+++ b/src/components/atoms/TopbarSwitchSelector.tsx
@@ -41,8 +41,9 @@ const TopbarSwitchSelector = ({
 export default TopbarSwitchSelector
 
 const Container = styled.div`
-  height: 28px;
   ${border}
+  height: 28px;
+  margin-left: 10px;
   border-radius: 4px;
   overflow: hidden;
 `
@@ -61,6 +62,7 @@ const ItemButton = styled.button`
     border-right: none;
   }
   &.active {
+    color: ${({ theme }) => theme.primaryButtonLabelColor};
     background-color: ${({ theme }) => theme.primaryColor};
   }
 `

--- a/src/lib/styled/BaseTheme.ts
+++ b/src/lib/styled/BaseTheme.ts
@@ -7,6 +7,7 @@ export interface BaseTheme {
   disabledUiTextColor: string
 
   primaryColor: string
+  primaryDarkerColor: string
   dangerColor: string
   borderColor: string
 

--- a/src/lib/styled/styleFunctions.ts
+++ b/src/lib/styled/styleFunctions.ts
@@ -87,7 +87,7 @@ export const contextMenuShadow = ({ theme }: StyledProps) =>
 export const inputStyle = ({ theme }: StyledProps) =>
   `background-color: ${theme.inputBackground};
 border: 1px solid ${theme.borderColor};
-border-radius: 4px;
+border-radius: 2px;
 color: ${theme.textColor};
 &:focus {
   box-shadow: 0 0 0 2px ${theme.primaryColor};
@@ -155,7 +155,7 @@ export const selectStyle = ({
   theme,
 }: StyledProps) => `background-color: ${theme.inputBackground};
 border: 1px solid ${theme.borderColor};
-border-radius: 4px;
+border-radius: 2px;
 color: ${theme.textColor};
 &:focus {
   box-shadow: 0 0 0 2px ${theme.primaryColor};

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -3,6 +3,8 @@ import { BaseTheme } from '../lib/styled/BaseTheme'
 const base1Color = '#2c2c2c'
 const base2Color = '#1e2022'
 const primaryColor = '#5580DC'
+const primaryDarkerColor = '#4070D8'
+const dangerColor = '#DC3545'
 
 const dark26Color = 'rgba(0,0,0,0.26)'
 const light70Color = 'rgba(255,255,255,0.7)'
@@ -27,7 +29,8 @@ export const darkTheme: BaseTheme = {
   disabledUiTextColor: light30Color,
 
   primaryColor: primaryColor,
-  dangerColor: '#dc3545',
+  primaryDarkerColor: primaryDarkerColor,
+  dangerColor: dangerColor,
   borderColor: '#505050',
   noteListIconColor: light30Color,
   noteListActiveIconColor: light70Color,
@@ -62,7 +65,7 @@ export const darkTheme: BaseTheme = {
   // Button
   primaryButtonLabelColor: light100Color,
   primaryButtonBackgroundColor: primaryColor,
-  primaryButtonHoverBackgroundColor: 'rgb(34, 89, 199)',
+  primaryButtonHoverBackgroundColor: primaryDarkerColor,
   secondaryButtonLabelColor: light100Color,
   secondaryButtonBackgroundColor: 'transparent',
 

--- a/src/themes/legacy.ts
+++ b/src/themes/legacy.ts
@@ -1,8 +1,10 @@
 import { BaseTheme } from '../lib/styled/BaseTheme'
 
 const base1Color = '#ECECEC'
-const base2Color = '#F9F9F9'
+const base2Color = '#D2D2D2'
 const primaryColor = '#5580DC'
+const primaryDarkerColor = '#4070D8'
+const dangerColor = '#DC3545'
 
 const dark87Color = 'rgba(0,0,0,0.87)'
 const dark54Color = 'rgba(0,0,0,0.54)'
@@ -30,7 +32,8 @@ export const legacyTheme: BaseTheme = {
   disabledUiTextColor: dark26Color,
 
   primaryColor: primaryColor,
-  dangerColor: '#dc3545',
+  primaryDarkerColor: primaryDarkerColor,
+  dangerColor: dangerColor,
   borderColor: dark12Color,
   noteListIconColor: dark26Color,
   noteListActiveIconColor: dark54Color,
@@ -65,7 +68,7 @@ export const legacyTheme: BaseTheme = {
   // Button
   primaryButtonLabelColor: light100Color,
   primaryButtonBackgroundColor: primaryColor,
-  primaryButtonHoverBackgroundColor: 'rgb(34, 89, 199)',
+  primaryButtonHoverBackgroundColor: primaryDarkerColor,
   secondaryButtonLabelColor: dark100Color,
   secondaryButtonBackgroundColor: 'transparent',
 

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -3,6 +3,8 @@ import { BaseTheme } from '../lib/styled/BaseTheme'
 const base1Color = '#ECECEC'
 const base2Color = '#F9F9F9'
 const primaryColor = '#5580DC'
+const primaryDarkerColor = '#4070D8'
+const dangerColor = '#DC3545'
 
 const dark87Color = 'rgba(0,0,0,0.87)'
 const dark54Color = 'rgba(0,0,0,0.54)'
@@ -36,7 +38,8 @@ export const lightTheme: BaseTheme = {
   disabledUiTextColor: dark26Color,
 
   primaryColor: primaryColor,
-  dangerColor: '#dc3545',
+  primaryDarkerColor: primaryDarkerColor,
+  dangerColor: dangerColor,
   borderColor: dark12Color,
 
   noteListIconColor: dark26Color,
@@ -72,7 +75,7 @@ export const lightTheme: BaseTheme = {
   // Button
   primaryButtonLabelColor: light100Color,
   primaryButtonBackgroundColor: primaryColor,
-  primaryButtonHoverBackgroundColor: 'rgb(34, 89, 199)',
+  primaryButtonHoverBackgroundColor: primaryDarkerColor,
   secondaryButtonLabelColor: dark100Color,
   secondaryButtonBackgroundColor: 'transparent',
 

--- a/src/themes/sepia.ts
+++ b/src/themes/sepia.ts
@@ -1,9 +1,11 @@
 import { BaseTheme } from '../lib/styled/BaseTheme'
 
 const base1Color = '#fdf6e4'
-const base2Color = '#efe8d6'
+const base2Color = '#fbebc3'
 const base3Color = '#393733'
 const primaryColor = '#b38925'
+const primaryDarkerColor = '#9e7921'
+const dangerColor = '#DC3545'
 
 const dark54Color = 'rgba(0,0,0,0.54)'
 const dark26Color = 'rgba(0,0,0,0.26)'
@@ -30,7 +32,8 @@ export const sepiaTheme: BaseTheme = {
   disabledUiTextColor: light30Color,
 
   primaryColor: primaryColor,
-  dangerColor: '#dc3545',
+  primaryDarkerColor: primaryDarkerColor,
+  dangerColor: dangerColor,
   borderColor: dark12Color,
 
   noteListIconColor: dark26Color,
@@ -66,7 +69,7 @@ export const sepiaTheme: BaseTheme = {
   // Button
   primaryButtonLabelColor: light100Color,
   primaryButtonBackgroundColor: primaryColor,
-  primaryButtonHoverBackgroundColor: 'rgb(34, 89, 199)',
+  primaryButtonHoverBackgroundColor: primaryDarkerColor,
   secondaryButtonLabelColor: base3Color,
   secondaryButtonBackgroundColor: 'transparent',
 

--- a/src/themes/solarizedDark.ts
+++ b/src/themes/solarizedDark.ts
@@ -1,8 +1,10 @@
 import { BaseTheme } from '../lib/styled/BaseTheme'
 
 const base1Color = '#1d3f48'
-const base2Color = '#18353d'
+const base2Color = '#162f36'
 const primaryColor = '#34a198'
+const primaryDarkerColor = '#2e8e86'
+const dangerColor = '#DC3545'
 
 const dark26Color = 'rgba(0,0,0,0.26)'
 const light70Color = 'rgba(255,255,255,0.7)'
@@ -26,7 +28,8 @@ export const solarizedDarkTheme: BaseTheme = {
   disabledUiTextColor: light30Color,
 
   primaryColor: primaryColor,
-  dangerColor: '#dc3545',
+  primaryDarkerColor: primaryDarkerColor,
+  dangerColor: dangerColor,
   borderColor: dark26Color,
   noteListIconColor: light30Color,
   noteListActiveIconColor: light70Color,
@@ -61,7 +64,7 @@ export const solarizedDarkTheme: BaseTheme = {
   // Button
   primaryButtonLabelColor: light100Color,
   primaryButtonBackgroundColor: primaryColor,
-  primaryButtonHoverBackgroundColor: 'rgb(34, 89, 199)',
+  primaryButtonHoverBackgroundColor: primaryDarkerColor,
   secondaryButtonLabelColor: light100Color,
   secondaryButtonBackgroundColor: 'transparent',
 


### PR DESCRIPTION
## Description
- Some colors in the topbar & buttons were broken, so I fixed them
- There were no styles for the tag input, so I added some styles
- I removed hover & active state from the tag list item for now (this one causing some color issues in some of the themes)

## Topbar

### Dark
![CleanShot 2020-10-26 at 16 35 05](https://user-images.githubusercontent.com/2410692/97147902-9a461f80-17ad-11eb-856f-9c20c8bf9d14.gif)

### Light
![CleanShot 2020-10-26 at 16 35 51](https://user-images.githubusercontent.com/2410692/97147932-a29e5a80-17ad-11eb-9e7e-cbccc27c544d.png)

### Sepia
![CleanShot 2020-10-26 at 16 36 11](https://user-images.githubusercontent.com/2410692/97147954-ab8f2c00-17ad-11eb-869a-7eb6af57af8b.png)

### Legacy
![CleanShot 2020-10-26 at 16 36 43](https://user-images.githubusercontent.com/2410692/97147963-b053e000-17ad-11eb-819c-23490ffbc14d.png)

### Solarized Dark
![CleanShot 2020-10-26 at 16 37 02](https://user-images.githubusercontent.com/2410692/97147980-b649c100-17ad-11eb-9340-3ac69f799746.png)

## New Note Button

### Before (Sepia & Solarized Dark)
![CleanShot 2020-10-26 at 15 10 48](https://user-images.githubusercontent.com/2410692/97148272-340dcc80-17ae-11eb-905a-9e9642596f81.gif)

### Dark, Light, and Legacy
![CleanShot 2020-10-26 at 16 48 07](https://user-images.githubusercontent.com/2410692/97148068-dd07f780-17ad-11eb-860c-69fd07f44f98.gif)

### Sepia
![CleanShot 2020-10-26 at 16 40 03](https://user-images.githubusercontent.com/2410692/97148148-fad55c80-17ad-11eb-9f3c-0069fc06718a.gif)

### Solarized Dark
![CleanShot 2020-10-26 at 17 10 04](https://user-images.githubusercontent.com/2410692/97148231-222c2980-17ae-11eb-9492-bbc23e7ecda2.gif)


