### PR TITLE
UI: Adjusted Preferences Modal Styles

### DIFF
--- a/src/components/PreferencesModal/MarkdownTab.tsx
+++ b/src/components/PreferencesModal/MarkdownTab.tsx
@@ -37,6 +37,8 @@ const PreviewContainer = styled.div`
   ${border}
   .panel {
     width: 50%;
+    padding: 15px;
+
     &:first-child {
       ${borderRight}
     }

--- a/src/components/PreferencesModal/PreferencesModal.tsx
+++ b/src/components/PreferencesModal/PreferencesModal.tsx
@@ -11,10 +11,10 @@ import BillingTab from './BillingTab'
 import {
   backgroundColor,
   closeIconColor,
-  borderLeft,
   border,
   flexCenter,
   borderBottom,
+  borderLeft,
 } from '../../lib/styled/styleFunctions'
 import { useTranslation } from 'react-i18next'
 import Icon from '../atoms/Icon'
@@ -72,6 +72,7 @@ const ModalTitle = styled.h1`
 const ModalBody = styled.div`
   display: flex;
   overflow: hidden;
+  height: 100%;
 `
 
 const TabNav = styled.nav`
@@ -82,7 +83,6 @@ const TabContent = styled.div`
   flex: 1;
   overflow-y: auto;
   padding: 1em;
-
   ${borderLeft}
 `
 

--- a/src/components/PreferencesModal/styled.tsx
+++ b/src/components/PreferencesModal/styled.tsx
@@ -48,6 +48,7 @@ export const SectionSelect = styled.select`
   width: 200px;
   height: 40px;
   border-radius: 2px;
+  font-size: 14px;
 
   option {
     color: initial;
@@ -79,6 +80,7 @@ export const SectionInput = styled.input`
   width: 200px;
   height: 40px;
   border-radius: 2px;
+  font-size: 14px;
 `
 
 export const SectionTable = styled.table`


### PR DESCRIPTION
## Description
- Made the sidebar border to full length
- Adjusted font sizes of the selector & input
- Added some padding to the markdown previewed

## Screenshots

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2020-10-26 at 17 52 20](https://user-images.githubusercontent.com/2410692/97154257-0711e780-17b7-11eb-9098-10b8378fb673.png)| ![image](https://user-images.githubusercontent.com/2410692/97154354-1db83e80-17b7-11eb-8d40-824ced26abba.png) |
| ![CleanShot 2020-10-26 at 18 05 05](https://user-images.githubusercontent.com/2410692/97154413-2f99e180-17b7-11eb-96b0-9a14f7341a39.png) | ![CleanShot 2020-10-26 at 18 03 32](https://user-images.githubusercontent.com/2410692/97154429-34f72c00-17b7-11eb-881b-d513732a0d56.png) |
| ![CleanShot 2020-10-26 at 18 09 26](https://user-images.githubusercontent.com/2410692/97154508-4d674680-17b7-11eb-907e-b806c2c02f12.png) | ![CleanShot 2020-10-26 at 18 10 07](https://user-images.githubusercontent.com/2410692/97154532-55bf8180-17b7-11eb-8032-333adf81aedd.png) |

