### PR TITLE
UI: Fixed Doc List Hover Styles

### DIFF
--- a/src/components/molecules/FolderDetailListItem.tsx
+++ b/src/components/molecules/FolderDetailListItem.tsx
@@ -44,7 +44,7 @@ const Container = styled.li`
   height: 40px;
   ${borderBottom}
   &:hover {
-    background-color: ${({ theme }) => theme.navItemHoverBackgroundColor};
+    background-color: ${({ theme }) => theme.noteNavItemBackgroundColor};
   }
   .clickable {
     flex: 1;

--- a/src/lib/styled/BaseTheme.ts
+++ b/src/lib/styled/BaseTheme.ts
@@ -39,6 +39,7 @@ export interface BaseTheme {
 
   // NotePage
   noteNavEmptyItemColor: string
+  noteNavItemBackgroundColor: string
 
   // Button
   primaryButtonLabelColor: string

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -61,6 +61,7 @@ export const darkTheme: BaseTheme = {
 
   // NotePage
   noteNavEmptyItemColor: '#999',
+  noteNavItemBackgroundColor: '#444',
 
   // Button
   primaryButtonLabelColor: light100Color,

--- a/src/themes/legacy.ts
+++ b/src/themes/legacy.ts
@@ -64,6 +64,7 @@ export const legacyTheme: BaseTheme = {
 
   // NotePage
   noteNavEmptyItemColor: '#999',
+  noteNavItemBackgroundColor: base2Color,
 
   // Button
   primaryButtonLabelColor: light100Color,

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -71,6 +71,7 @@ export const lightTheme: BaseTheme = {
 
   // NotePage
   noteNavEmptyItemColor: uiDimColor,
+  noteNavItemBackgroundColor: uiVividBackgroundColor,
 
   // Button
   primaryButtonLabelColor: light100Color,

--- a/src/themes/sepia.ts
+++ b/src/themes/sepia.ts
@@ -65,6 +65,7 @@ export const sepiaTheme: BaseTheme = {
 
   // NotePage
   noteNavEmptyItemColor: '#777',
+  noteNavItemBackgroundColor: '#eee8d6',
 
   // Button
   primaryButtonLabelColor: light100Color,

--- a/src/themes/solarizedDark.ts
+++ b/src/themes/solarizedDark.ts
@@ -10,6 +10,8 @@ const dark26Color = 'rgba(0,0,0,0.26)'
 const light70Color = 'rgba(255,255,255,0.7)'
 const light30Color = 'rgba(255,255,255,0.3)'
 const light12Color = 'rgba(255,255,255,0.12)'
+const light18Color = 'rgba(255,255,255,0.18)'
+const light24Color = 'rgba(255,255,255,0.24)'
 const light100Color = '#FFF'
 
 export const solarizedDarkTheme: BaseTheme = {
@@ -53,13 +55,14 @@ export const solarizedDarkTheme: BaseTheme = {
   navButtonActiveColor: primaryColor,
   navItemColor: '#bbb',
   navItemBackgroundColor: 'transparent',
-  navItemHoverBackgroundColor: '#0E404D',
+  navItemHoverBackgroundColor: light12Color,
   navItemActiveColor: '#eee',
-  navItemActiveBackgroundColor: '#0E404D',
-  navItemHoverActiveBackgroundColor: '#104B59',
+  navItemActiveBackgroundColor: light24Color,
+  navItemHoverActiveBackgroundColor: light18Color,
 
   // NotePage
   noteNavEmptyItemColor: '#bbb',
+  noteNavItemBackgroundColor: light12Color,
 
   // Button
   primaryButtonLabelColor: light100Color,


### PR DESCRIPTION
## Description
- Legacy theme and Solarized Dark theme had weird hover style on the doc list, so I fixed the colors
- While doing that, I also had to fix the nav background colors of the side nav (only solarized dark)

## Screenshots

### Before

#### Legacy
![CleanShot 2020-10-26 at 19 39 16](https://user-images.githubusercontent.com/2410692/97165673-6841b700-17c7-11eb-84a0-03e72732df16.png)

#### Solarized Dark
![image](https://user-images.githubusercontent.com/2410692/97165790-9921ec00-17c7-11eb-8891-69b863982ff9.png)

### After

#### Legacy
![CleanShot 2020-10-26 at 19 59 43](https://user-images.githubusercontent.com/2410692/97165829-a6d77180-17c7-11eb-820e-ed9c6e6338b6.png)

#### Solarized Dark
![CleanShot 2020-10-26 at 20 06 16](https://user-images.githubusercontent.com/2410692/97165857-af2fac80-17c7-11eb-8739-35cdf9b5d9a7.png)

![CleanShot 2020-10-26 at 20 09 02](https://user-images.githubusercontent.com/2410692/97165869-b5258d80-17c7-11eb-8a57-3d3044124e65.gif)

