### PR TITLE
Add homepage translation for Croatian (#462)

### DIFF
--- a/homepage/components/organisms/Header.tsx
+++ b/homepage/components/organisms/Header.tsx
@@ -310,6 +310,7 @@ const Header = () => {
               <option value='ru'>🇷🇺</option>
               <option value='vn'>🇻🇳</option>
               <option value='zh'>🇨🇳</option>
+              <option value='hr'>🇭🇷</option>
             </HeaderLanguageSelect>
           </HeaderNavigator>
         </Container>

--- a/homepage/lib/i18n.ts
+++ b/homepage/lib/i18n.ts
@@ -11,6 +11,7 @@ import ru from '../locales/ru'
 import es from '../locales/es'
 import de from '../locales/de'
 import vn from '../locales/vn'
+import hr from '../locales/hr'
 
 const resources = {
   en,
@@ -24,6 +25,7 @@ const resources = {
   es,
   de,
   vn,
+  hr
 }
 
 i18n

--- a/homepage/locales/hr.ts
+++ b/homepage/locales/hr.ts
@@ -1,0 +1,94 @@
+export default {
+    translation: {
+      common: {
+        openInBrowser: 'Otvori u pregledniku',
+        downloadApp: 'Preuzmi aplikaciju',
+        fileSystemBasedStorage: 'Pohrana podataka na datotečnom sustavu',
+        comingSoon: 'Dolazi uskoro',
+        webApp: 'Web aplikacija',
+        desktopApp: 'Desktop aplikacija',
+        mobileApp: 'Mobilna aplikacija',
+        boostHub: 'Napravite račun besplatno',
+      },
+      header: {
+        forTeams: 'Za timove',
+        community: 'Zajednica',
+      },
+      hero: {
+        title: 'Povećajte sreću, produktivnost i kreativnost.',
+        subtitle:
+          "Boost Note je intuitivan i moderan uređivač teksta. Otvorenog je koda i koristi ga milijun programera!",
+      },
+      boostHub: {
+        title: 'Boost Hub, inačica Boost Notea za timove',
+        description1: 'Razvili smo aplikaciju za zajednički radni prostor nazvanu “Boost Hub” za timove programera.',
+        description2:
+          'Ima više od samog uređivača teksta ili wikija. Možete surađivati sa svojim timom u stvarnom vremenu, od bilokuda.',
+        feature1Name: 'Koautorstvo u stvarnom vremenu',
+        feature1Detail:
+          'Pišite i uređujte dokumente kao tim, dijeleći pritom svoje znanje i ideje u stvarnom vremenu. Nitko neće biti zapostavljen.',
+        feature2Name: 'Stvorite dijagrame poput profesionalca',
+        feature2Detail:
+          'Dostupna je podrška za Charts.js, Mermaid i PlantUML, što znači da u dokument možete staviti dijagrame.',
+        feature3Name: 'Prekrasan prikaz matematičkih bilježaka',
+        feature3Detail:
+          'Za preglednu reprezentaciju matematičkih jednadžbi, vrijeme je da koristite LaTex unutar vašeg Boost Hub uređivača.',
+      },
+      features: {
+        title: 'Značajke',
+        cloudStorage: 'Pohrana podataka u oblaku',
+        cloudStorageDescription:
+          'Bilješke spremljene u oblaku su sigurne i dostupne na svim uređajima.',
+        multiplePlatforms: 'Više platformi',
+        multiplePlatformsDescription:
+          'Boost Note aplikacija dostupna je u preglednicima, te kao desktop i mobilna aplikacija.',
+        syntaxHighlight: 'Podrška za isticanje sintakse',
+        syntaxHighlightDescription:
+          'Boost Note može istaknuti sintaksu za više od 100 programskih jezika.',
+        mathEquations: 'Matematičke jednadžbe',
+        mathEquationsDescription:
+          'Boost Note podržava matematičke blokove u kojima možete pisati jednadžbe pomoću LaTeX sintakse.',
+        customizableTheme: 'Prilagodljiv stil',
+        customizableThemeDescription:
+          'Možete prilagoditi stil korisničkog sučelja, uređivača teksta te način prikaza sadržaja kod Markdown sintakse.',
+        fileSystemBasedStorageDescription:
+          'Možete imati potpunu kontrolu nad svojim podacima. Podijelite svoje bilješke sa svojom omiljenom uslugom za pohranu podataka u oblaku.',
+        extensibleMarkdown: 'Proširena Markdown sintaksa (dolazi uskoro)',
+        extensibleMarkdownDescription:
+          'Možete unjeti svoju prilagođenu Markdown sintaksu te prilagoditi način njezinog prikaza.',
+      },
+      pricing: {
+        title: 'Cijena usluga',
+        feature: 'Značajka',
+        basic: 'Osnovno',
+        premium: 'Premium',
+        sync: 'Dijeljenje podataka na više uređaja',
+        localStorageSize: 'Veličina lokalnog prostora',
+        unlimited: 'Neograničeno',
+        cloudStorageSize: 'Veličina prostora u oblaku',
+        price: 'Cijena',
+        free: 'Besplatno',
+        month: 'Mjesec',
+        furtherPlan: 'Nakon toga, 5$ (USD) za svakih 5GB.',
+      },
+      download: {
+        legacyApp: 'Stara aplikacija',
+        legacyAppDescription:
+          "Nastavit ćemo održavati staru aplikaciju sve dok trenutni BoostNote.next ne podrži većinu značajki stare aplikacije, poput pohrane podataka preko datotečnog sustava i proširenja markdown sintakse. Stoga nemojte žuriti s prelaskom na novu aplikaciju.",
+        legacyDownloadLinks: 'Veze za preuzimanje stare aplikacije',
+        legacyRepository: 'Repozitorij stare aplikacije',
+      },
+      community: {
+        title: 'Pridružite se našoj zajednici',
+        description:
+          'Naša zajednica programera podržava Boostnote. Boostnote je stekao popularnost na GitHub-u i podržava ga mnoštvo suradnika iz preko 200 zemalja i regija. Naša zajednica Vam želi dobrodošlicu. Budite i vi dio naše zajednice!',
+      },
+      footer: {
+        mission: 'Misija',
+        pressKit: 'Za medije',
+        backers: 'Podržavatelji',
+        userTerms: 'Korisnički uvjeti',
+        privacyPolicy: 'Pravila o privatnosti',
+      },
+    },
+  }


### PR DESCRIPTION
Add homepage translation for Croatian language.

Original Translation: https://github.com/BoostIO/BoostNote.next/blob/master/homepage/locales/en.ts