### PR TITLE
UI: Restyled App Navigators

### DIFF
--- a/src/components/molecules/AppNavigatorStorageItem.tsx
+++ b/src/components/molecules/AppNavigatorStorageItem.tsx
@@ -18,43 +18,45 @@ import { openContextMenu } from '../../lib/electronOnly'
 import { useStorageRouter } from '../../lib/storageRouter'
 
 const Container = styled.div`
+  ${flexCenter}
   position: relative;
   height: 48px;
   width: 48px;
   margin-bottom: 4px;
-  &:first-child {
-    margin-top: 10px;
-  }
-  ${flexCenter}
   border-radius: 14px;
   border-width: 3px;
   border-style: solid;
   border-color: transparent;
+
+  &:first-child {
+    margin-top: 10px;
+  }
+  &:hover {
+    border-color: ${({ theme }) => theme.borderColor};
+  }
   &.active {
     border-color: ${({ theme }) => theme.textColor};
   }
 `
 
 const MainButton = styled.button`
+  ${flexCenter}
   height: 36px;
   width: 36px;
   border-radius: 8px;
-  ${border}
   cursor: pointer;
-  ${flexCenter}
   font-size: 18px;
   border: none;
-  background-color: ${({ theme }) => theme.secondaryButtonBackgroundColor};
-  color: ${({ theme }) => theme.secondaryButtonLabelColor};
-  border: 1px solid ${({ theme }) => theme.borderColor};
+  background-color: ${({ theme }) => theme.teamSwitcherBackgroundColor};
+  border: 1px solid ${({ theme }) => theme.teamSwitcherBorderColor};
+  color: ${({ theme }) => theme.teamSwitcherTextColor};
   font-size: 13px;
 
-  &:hover,
   &:active,
   &.active {
+    background-color: ${({ theme }) => theme.teamSwitcherHoverBackgroundColor};
+    color: ${({ theme }) => theme.teamSwitcherHoverTextColor};
     cursor: pointer;
-    color: ${({ theme }) => theme.secondaryButtonHoverLabelColor};
-    background-color: ${({ theme }) => theme.primaryColor};
   }
 
   &:disabled {

--- a/src/components/organisms/AppNavigator.tsx
+++ b/src/components/organisms/AppNavigator.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useCallback, MouseEventHandler } from 'react'
 import styled from '../../lib/styled'
 import {
   borderRight,
-  border,
   secondaryButtonStyle,
   flexCenter,
 } from '../../lib/styled/styleFunctions'
@@ -238,11 +237,10 @@ const ControlContainer = styled.div`
 `
 
 const NavigatorButton = styled.button`
-  position: relative;
   ${secondaryButtonStyle}
+  position: relative;
   height: 36px;
   width: 36px;
-  ${border}
   margin-bottom: 8px;
   display: flex;
   align-items: center;
@@ -250,6 +248,8 @@ const NavigatorButton = styled.button`
   cursor: pointer;
   font-size: 22px;
   border-radius: 8px;
+  border: none;
+
   &:first-child {
     margin-top: 5px;
   }

--- a/src/lib/styled/BaseTheme.ts
+++ b/src/lib/styled/BaseTheme.ts
@@ -41,6 +41,13 @@ export interface BaseTheme {
   noteNavEmptyItemColor: string
   noteNavItemBackgroundColor: string
 
+  // Team Switcher
+  teamSwitcherBackgroundColor: string
+  teamSwitcherBorderColor: string
+  teamSwitcherTextColor: string
+  teamSwitcherHoverBackgroundColor: string
+  teamSwitcherHoverTextColor: string
+
   // Button
   primaryButtonLabelColor: string
   primaryButtonBackgroundColor: string

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -6,6 +6,7 @@ const primaryColor = '#5580DC'
 const primaryDarkerColor = '#4070D8'
 const dangerColor = '#DC3545'
 
+const dark54Color = 'rgba(0,0,0,0.54)'
 const dark26Color = 'rgba(0,0,0,0.26)'
 const light70Color = 'rgba(255,255,255,0.7)'
 const light30Color = 'rgba(255,255,255,0.3)'
@@ -58,6 +59,13 @@ export const darkTheme: BaseTheme = {
   navItemActiveColor: '#eee',
   navItemActiveBackgroundColor: '#444',
   navItemHoverActiveBackgroundColor: '#555',
+
+  // Team Switcher
+  teamSwitcherBackgroundColor: light100Color,
+  teamSwitcherBorderColor: 'transparent',
+  teamSwitcherTextColor: dark54Color,
+  teamSwitcherHoverBackgroundColor: light100Color,
+  teamSwitcherHoverTextColor: dark54Color,
 
   // NotePage
   noteNavEmptyItemColor: '#999',

--- a/src/themes/legacy.ts
+++ b/src/themes/legacy.ts
@@ -62,6 +62,13 @@ export const legacyTheme: BaseTheme = {
   navItemActiveBackgroundColor: '#444',
   navItemHoverActiveBackgroundColor: '#555',
 
+  // Team Switcher
+  teamSwitcherBackgroundColor: light100Color,
+  teamSwitcherBorderColor: 'transparent',
+  teamSwitcherTextColor: dark54Color,
+  teamSwitcherHoverBackgroundColor: light100Color,
+  teamSwitcherHoverTextColor: dark54Color,
+
   // NotePage
   noteNavEmptyItemColor: '#999',
   noteNavItemBackgroundColor: base2Color,

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -69,6 +69,13 @@ export const lightTheme: BaseTheme = {
   navItemActiveBackgroundColor: uiVividBackgroundColor,
   navItemHoverActiveBackgroundColor: uiVivid2BackgroundColor,
 
+  // Team Switcher
+  teamSwitcherBackgroundColor: light100Color,
+  teamSwitcherBorderColor: dark12Color,
+  teamSwitcherTextColor: dark54Color,
+  teamSwitcherHoverBackgroundColor: light100Color,
+  teamSwitcherHoverTextColor: dark54Color,
+
   // NotePage
   noteNavEmptyItemColor: uiDimColor,
   noteNavItemBackgroundColor: uiVividBackgroundColor,

--- a/src/themes/sepia.ts
+++ b/src/themes/sepia.ts
@@ -63,6 +63,13 @@ export const sepiaTheme: BaseTheme = {
   navItemActiveBackgroundColor: '#eee8d6',
   navItemHoverActiveBackgroundColor: '#e0e0e0',
 
+  // Team Switcher
+  teamSwitcherBackgroundColor: '#eee8d6',
+  teamSwitcherBorderColor: 'transparent',
+  teamSwitcherTextColor: base3Color,
+  teamSwitcherHoverBackgroundColor: primaryColor,
+  teamSwitcherHoverTextColor: light100Color,
+
   // NotePage
   noteNavEmptyItemColor: '#777',
   noteNavItemBackgroundColor: '#eee8d6',

--- a/src/themes/solarizedDark.ts
+++ b/src/themes/solarizedDark.ts
@@ -32,7 +32,7 @@ export const solarizedDarkTheme: BaseTheme = {
   primaryColor: primaryColor,
   primaryDarkerColor: primaryDarkerColor,
   dangerColor: dangerColor,
-  borderColor: dark26Color,
+  borderColor: light12Color,
   noteListIconColor: light30Color,
   noteListActiveIconColor: light70Color,
   noteDetailIconColor: light30Color,
@@ -59,6 +59,13 @@ export const solarizedDarkTheme: BaseTheme = {
   navItemActiveColor: '#eee',
   navItemActiveBackgroundColor: light24Color,
   navItemHoverActiveBackgroundColor: light18Color,
+
+  // Team Switcher
+  teamSwitcherBackgroundColor: light12Color,
+  teamSwitcherBorderColor: dark26Color,
+  teamSwitcherTextColor: light100Color,
+  teamSwitcherHoverBackgroundColor: primaryColor,
+  teamSwitcherHoverTextColor: light100Color,
 
   // NotePage
   noteNavEmptyItemColor: '#bbb',


### PR DESCRIPTION
## Description
I restyled the app navigators.

## Screenshots

### Light
![CleanShot 2020-11-16 at 22 22 40](https://user-images.githubusercontent.com/2410692/99259190-fbb55780-285c-11eb-8f42-fe2daa1dfef5.gif)

### Dark
![CleanShot 2020-11-16 at 22 15 34](https://user-images.githubusercontent.com/2410692/99259191-fbb55780-285c-11eb-97dd-d78a671e72c9.gif)

### Legacy
![CleanShot 2020-11-16 at 22 23 43](https://user-images.githubusercontent.com/2410692/99259189-fb1cc100-285c-11eb-8d94-3d72ed861304.gif)

### Sepia
GIF doesn't look good, but you can check the actual color from the image instead ;)
![CleanShot 2020-11-16 at 22 35 43](https://user-images.githubusercontent.com/2410692/99259170-f5bf7680-285c-11eb-8dfc-e1c4d7b1347b.gif)
![image](https://user-images.githubusercontent.com/2410692/99259357-37502180-285d-11eb-9f18-1dd72b740aef.png)

### Solarized Dark
![CleanShot 2020-11-16 at 22 33 47](https://user-images.githubusercontent.com/2410692/99259185-f9eb9400-285c-11eb-97b2-10c856191a62.gif)
