### PR TITLE
Add checkmarks instead of circles in billing page (#388)

### DIFF
--- a/src/components/PreferencesModal/BillingTab.tsx
+++ b/src/components/PreferencesModal/BillingTab.tsx
@@ -112,33 +112,33 @@ const BillingTab = () => {
           <tbody>
             <tr>
               <th>{t('billing.browser')}</th>
-              <td>〇</td>
-              <td>〇</td>
+              <td>&#10003;</td>
+              <td>&#10003;</td>
             </tr>
             <tr>
               <th>{t('billing.desktop')}</th>
-              <td>〇</td>
-              <td>〇</td>
+              <td>&#10003;</td>
+              <td>&#10003;</td>
             </tr>
             <tr>
               <th>{t('billing.mobile')}</th>
-              <td>〇</td>
-              <td>〇</td>
+              <td>&#10003;</td>
+              <td>&#10003;</td>
             </tr>
             <tr>
               <th>{t('billing.sync')}</th>
-              <td>〇</td>
-              <td>〇</td>
+              <td>&#10003;</td>
+              <td>&#10003;</td>
             </tr>
             <tr>
               <th>{t('billing.local')}</th>
-              <td>〇</td>
-              <td>〇</td>
+              <td>&#10003;</td>
+              <td>&#10003;</td>
             </tr>
             <tr>
               <th>{t('billing.cloud')}</th>
-              <td>〇</td>
-              <td>〇</td>
+              <td>&#10003;</td>
+              <td>&#10003;</td>
             </tr>
             <tr>
               <th>{t('billing.storageSize')}</th>


### PR DESCRIPTION
**Add checkmarks instead of circles in billing page** (commit-sha)

Update billing page basic and premium to have checkmarks arrows instead of empty circles

The billing page was:
![BillingPageBefore](https://user-images.githubusercontent.com/18196945/99290444-95b9d780-283e-11eb-8152-d3f80e423865.png)

Now is:
![BillingPageNow](https://user-images.githubusercontent.com/18196945/99290449-981c3180-283e-11eb-82aa-7cb331892ac6.png)

**Test:** 
In electron Linux App (dev)
In electron Linux App production version (appImage)