### PR TITLE
Add initial open note-link functionality (#313)

### DIFF
--- a/src/components/atoms/CodeEditor.tsx
+++ b/src/components/atoms/CodeEditor.tsx
@@ -33,6 +33,16 @@ const StyledContainer = styled.div`
     color: ${({ theme }) => theme.primaryButtonLabelColor};
     background-color: ${({ theme }) => theme.primaryColor};
   }
+
+  .CodeMirror-hyperlink {
+    cursor: pointer;
+  }
+
+  .CodeMirror-hover {
+    padding: 2px 4px 0 4px;
+    position: absolute;
+    z-index: 99;
+  }
 `
 
 const defaultCodeMirrorOptions: CodeMirror.EditorConfiguration = {

--- a/src/components/molecules/FolderNoteNavigatorFragment.tsx
+++ b/src/components/molecules/FolderNoteNavigatorFragment.tsx
@@ -4,6 +4,7 @@ import {
   NoteDoc,
   PopulatedFolderDoc,
   ObjectMap,
+  NoteDocEditibleProps,
 } from '../../lib/db/types'
 import { useRouteParams, StorageNotesRouteParams } from '../../lib/routeParams'
 import { useGeneralStatus } from '../../lib/generalStatus'
@@ -25,6 +26,11 @@ interface FolderNoteNavigatorFragment {
     noteId: string
   ) => Promise<NoteDoc | undefined>
   trashNote: (storageId: string, noteId: string) => Promise<NoteDoc | undefined>
+  copyNoteLink: (
+    storageId: string,
+    noteId: string,
+    noteProps: Partial<NoteDocEditibleProps>
+  ) => Promise<string | undefined>
 }
 
 const FolderNoteNavigatorFragment = ({
@@ -35,6 +41,7 @@ const FolderNoteNavigatorFragment = ({
   bookmarkNote,
   unbookmarkNote,
   trashNote,
+  copyNoteLink,
 }: FolderNoteNavigatorFragment) => {
   const { folderMap, id: storageId } = storage
 
@@ -145,6 +152,7 @@ const FolderNoteNavigatorFragment = ({
             bookmarkNote={bookmarkNote}
             unbookmarkNote={unbookmarkNote}
             trashNote={trashNote}
+            copyNoteLink={copyNoteLink}
           />
         )
       })}

--- a/src/components/molecules/NoteItem.tsx
+++ b/src/components/molecules/NoteItem.tsx
@@ -22,6 +22,7 @@ import { bookmarkItemId } from '../../lib/nav'
 import { openContextMenu } from '../../lib/electronOnly'
 import { BaseTheme } from '../../lib/styled/BaseTheme'
 import { isColorBright } from '../../lib/colors'
+import { useToast } from '../../lib/toast'
 
 const Container = styled.button`
   margin: 0;
@@ -136,6 +137,7 @@ const NoteItem = ({
   const href = `${basePathname}/${note._id}`
   const {
     createNote,
+    copyNoteLink,
     trashNote,
     purgeNote,
     untrashNote,
@@ -146,6 +148,7 @@ const NoteItem = ({
   const { addSideNavOpenedItem } = useGeneralStatus()
 
   const { messageBox } = useDialog()
+  const { pushMessage } = useToast()
   const { t } = useTranslation()
 
   const openUntrashedNoteContextMenu = useCallback(
@@ -166,6 +169,32 @@ const NoteItem = ({
                 tags: note.tags,
                 data: note.data,
               })
+            },
+          },
+          {
+            type: 'normal',
+            label: 'Copy note link',
+            click: async () => {
+              const noteLink = await copyNoteLink(storageId, note._id, {
+                title: note.title,
+                content: note.content,
+                folderPathname: note.folderPathname,
+                tags: note.tags,
+                data: note.data,
+              })
+              if (noteLink) {
+                pushMessage({
+                  title: 'Note Link Copied',
+                  description:
+                    'Paste note link in any note to add a link to it',
+                })
+              } else {
+                pushMessage({
+                  title: 'Note Link Error',
+                  description:
+                    'An error occurred while attempting to create a note link',
+                })
+              }
             },
           },
           { type: 'separator' },
@@ -211,21 +240,23 @@ const NoteItem = ({
       })
     },
     [
-      createNote,
-      storageId,
+      note.data,
       note.title,
       note.content,
       note.folderPathname,
       note.tags,
-      note.data,
-      note.trashed,
       note._id,
-      trashNote,
+      note.trashed,
       applyDefaultNoteListing,
       applyCompactListing,
+      createNote,
+      storageId,
+      copyNoteLink,
+      pushMessage,
+      trashNote,
       bookmarkNote,
-      unbookmarkNote,
       addSideNavOpenedItem,
+      unbookmarkNote,
     ]
   )
 

--- a/src/components/molecules/NoteNavigatorItem.tsx
+++ b/src/components/molecules/NoteNavigatorItem.tsx
@@ -2,9 +2,11 @@ import React, { useCallback, MouseEventHandler } from 'react'
 import NavigatorItem from '../atoms/NavigatorItem'
 import { mdiCardTextOutline, mdiDotsVertical } from '@mdi/js'
 import { useStorageRouter } from '../../lib/storageRouter'
-import { NoteDoc } from '../../lib/db/types'
+import { NoteDoc, NoteDocEditibleProps } from '../../lib/db/types'
 import NavigatorButton from '../atoms/NavigatorButton'
 import { openContextMenu } from '../../lib/electronOnly'
+import { useToast } from '../../lib/toast'
+import copy from 'copy-to-clipboard'
 
 interface NoteNavigatorItemProps {
   storageId: string
@@ -23,6 +25,11 @@ interface NoteNavigatorItemProps {
     noteId: string
   ) => Promise<NoteDoc | undefined>
   trashNote: (storageId: string, noteId: string) => Promise<NoteDoc | undefined>
+  copyNoteLink: (
+    storageId: string,
+    noteId: string,
+    noteProps: Partial<NoteDocEditibleProps>
+  ) => Promise<string | undefined>
 }
 
 const NoteNavigatorItem = ({
@@ -36,9 +43,11 @@ const NoteNavigatorItem = ({
   bookmarkNote,
   unbookmarkNote,
   trashNote,
+  copyNoteLink,
 }: NoteNavigatorItemProps) => {
   const emptyTitle = noteTitle.trim().length === 0
   const { navigateToNote } = useStorageRouter()
+  const { pushMessage } = useToast()
 
   const navigate = useCallback(() => {
     navigateToNote(storageId, noteId, noteFolderPath)
@@ -47,6 +56,7 @@ const NoteNavigatorItem = ({
   const openNoteContextMenu: MouseEventHandler = useCallback(
     (event) => {
       event.preventDefault()
+      event.stopPropagation()
       openContextMenu({
         menuItems: [
           !noteBookmarked
@@ -64,6 +74,31 @@ const NoteNavigatorItem = ({
               },
           { type: 'separator' },
           {
+            type: 'normal',
+            label: 'Copy note link',
+            click: async () => {
+              const noteLink = await copyNoteLink(storageId, noteId, {
+                title: noteTitle,
+                folderPathname: noteFolderPath,
+              })
+              if (noteLink) {
+                copy(noteLink)
+                pushMessage({
+                  title: 'Note Link Copied',
+                  description:
+                    'Paste note link in any note to add a link to it',
+                })
+              } else {
+                pushMessage({
+                  title: 'Note Link Error',
+                  description:
+                    'An error occurred while attempting to create a note link',
+                })
+              }
+            },
+          },
+          { type: 'separator' },
+          {
             label: 'Trash Note',
             click: () => {
               trashNote(storageId, noteId)
@@ -72,7 +107,18 @@ const NoteNavigatorItem = ({
         ],
       })
     },
-    [storageId, noteId, noteBookmarked, bookmarkNote, unbookmarkNote, trashNote]
+    [
+      noteBookmarked,
+      bookmarkNote,
+      storageId,
+      noteId,
+      unbookmarkNote,
+      copyNoteLink,
+      noteTitle,
+      noteFolderPath,
+      pushMessage,
+      trashNote,
+    ]
   )
 
   return (

--- a/src/components/molecules/StorageNavigatorFragment.tsx
+++ b/src/components/molecules/StorageNavigatorFragment.tsx
@@ -53,6 +53,7 @@ const StorageNavigatorFragment = ({
     bookmarkNote,
     unbookmarkNote,
     trashNote,
+    copyNoteLink,
   } = useDb()
   const { push } = useRouter()
   const { t } = useTranslation()
@@ -274,6 +275,7 @@ const StorageNavigatorFragment = ({
           bookmarkNote={bookmarkNote}
           unbookmarkNote={unbookmarkNote}
           trashNote={trashNote}
+          copyNoteLink={copyNoteLink}
         />
       )}
 

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -21,7 +21,7 @@ import 'codemirror/keymap/vim'
 import 'codemirror-abap'
 
 // Custom addons
-import {initHyperlink} from './addons/hyperlink'
+import { initHyperlink } from './addons/hyperlink'
 
 const dispatchModeLoad = debounce(() => {
   window.dispatchEvent(new CustomEvent('codemirror-mode-load'))

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -20,6 +20,9 @@ import 'codemirror/keymap/emacs'
 import 'codemirror/keymap/vim'
 import 'codemirror-abap'
 
+// Custom addons
+import {initHyperlink} from './addons/hyperlink'
+
 const dispatchModeLoad = debounce(() => {
   window.dispatchEvent(new CustomEvent('codemirror-mode-load'))
 }, 300)
@@ -63,6 +66,8 @@ function loadMode(_CodeMirror: any) {
   }
 }
 
+// Initialize custom addons
+initHyperlink(CodeMirror)
 loadMode(CodeMirror)
 
 export default CodeMirror

--- a/src/lib/addons/hyperlink.js
+++ b/src/lib/addons/hyperlink.js
@@ -1,0 +1,186 @@
+import { openExternal, getWebContentsById } from '../electronOnly'
+import { osName } from '../platform'
+
+export function initHyperlink(CodeMirror) {
+  const eventEmitter = {
+    emit: function (eventType, href) {
+      const webContents = getWebContentsById(1)
+      if (webContents) {
+        webContents.send(eventType, href)
+      } else {
+        console.log('[DEBUG]: No window for web contents id:1')
+      }
+    },
+  }
+  const yOffset = 2
+
+  const macOS = osName === 'macos'
+  const modifier = macOS ? 'metaKey' : 'ctrlKey'
+
+  class HyperLink {
+    constructor(cm) {
+      this.cm = cm
+      this.lineDiv = cm.display.lineDiv
+
+      this.onMouseDown = this.onMouseDown.bind(this)
+      this.onMouseEnter = this.onMouseEnter.bind(this)
+      this.onMouseLeave = this.onMouseLeave.bind(this)
+      this.onMouseMove = this.onMouseMove.bind(this)
+
+      this.tooltip = document.createElement('div')
+      this.tooltipContent = document.createElement('div')
+      this.tooltipIndicator = document.createElement('div')
+      this.tooltip.setAttribute(
+        'class',
+        'CodeMirror-hover CodeMirror-matchingbracket CodeMirror-selected'
+      )
+      this.tooltip.setAttribute('cm-ignore-events', 'true')
+      this.tooltip.appendChild(this.tooltipContent)
+      this.tooltip.appendChild(this.tooltipIndicator)
+      this.tooltipContent.textContent = `${
+        macOS ? 'Cmd(⌘)' : 'Ctrl(^)'
+      } + click to follow link`
+
+      this.lineDiv.addEventListener('mousedown', this.onMouseDown)
+      this.lineDiv.addEventListener('mouseenter', this.onMouseEnter, {
+        capture: true,
+        passive: true,
+      })
+      this.lineDiv.addEventListener('mouseleave', this.onMouseLeave, {
+        capture: true,
+        passive: true,
+      })
+      this.lineDiv.addEventListener('mousemove', this.onMouseMove, {
+        passive: true,
+      })
+    }
+
+    getUrl(el) {
+      const className = el.className.split(' ')
+      if (className.indexOf('cm-url') !== -1) {
+        // multiple cm-url because of search term
+        const cmUrlSpans = Array.from(
+          el.parentNode.getElementsByClassName('cm-url')
+        )
+        const textContent =
+          cmUrlSpans.length > 1
+            ? cmUrlSpans.map((span) => span.textContent).join('')
+            : el.textContent
+
+        const match = /^\((.*)\)|\[(.*)]|(.*)$/.exec(textContent)
+        const url = match[1] || match[2] || match[3]
+        return /^:storage(?:\/|%5C)/.test(url) ? null : url
+      }
+
+      return null
+    }
+
+    specialLinkHandler(e, rawHref, linkHash) {
+      // This wil match shortId note id
+      // :note:cs23_d12 up to :note:cs23_d122bgCol
+      const regexIsNoteShortIdLink = /^:note:([a-zA-Z0-9_\-]{7,14})$/
+      if (regexIsNoteShortIdLink.test(linkHash)) {
+        eventEmitter.emit('note:navigate', linkHash.replace(':note:', ''))
+        return true
+      }
+
+      return false
+    }
+
+    onMouseDown(e) {
+      const { target } = e
+      if (!e[modifier]) {
+        return
+      }
+
+      // Create URL spans array used for special case "search term is hitting a link".
+      const cmUrlSpans = Array.from(
+        e.target.parentNode.getElementsByClassName('cm-url')
+      )
+
+      const innerText =
+        cmUrlSpans.length > 1
+          ? cmUrlSpans.map((span) => span.textContent).join('')
+          : e.target.innerText
+      const rawHref = innerText.trim().slice(1, -1) // get link text from markdown text
+
+      if (!rawHref) return // not checked href because parser will create file://... string for [empty link]()
+
+      const parser = document.createElement('a')
+      parser.href = rawHref
+      const { href, hash } = parser
+      // needed because we're having special link formats that are removed by parser e.g. :line:10
+      const linkHash = hash === '' ? rawHref : hash
+      const foundUrl = this.specialLinkHandler(target, rawHref, linkHash)
+
+      if (!foundUrl) {
+        const url = this.getUrl(target)
+        // all special cases handled --> other case
+        if (url) {
+          e.preventDefault()
+          openExternal(url)
+        }
+      }
+    }
+
+    onMouseEnter(e) {
+      const { target } = e
+
+      const url = this.getUrl(target)
+      if (url) {
+        if (e[modifier]) {
+          target.classList.add(
+            'CodeMirror-activeline-background',
+            'CodeMirror-hyperlink'
+          )
+        } else {
+          target.classList.add('CodeMirror-activeline-background')
+        }
+
+        this.showInfo(target)
+      }
+    }
+
+    onMouseLeave(e) {
+      if (this.tooltip.parentElement === this.lineDiv) {
+        e.target.classList.remove(
+          'CodeMirror-activeline-background',
+          'CodeMirror-hyperlink'
+        )
+
+        this.lineDiv.removeChild(this.tooltip)
+      }
+    }
+
+    onMouseMove(e) {
+      if (this.tooltip.parentElement === this.lineDiv) {
+        if (e[modifier]) {
+          e.target.classList.add('CodeMirror-hyperlink')
+        } else {
+          e.target.classList.remove('CodeMirror-hyperlink')
+        }
+      }
+    }
+
+    showInfo(relatedTo) {
+      const b1 = relatedTo.getBoundingClientRect()
+      const b2 = this.lineDiv.getBoundingClientRect()
+      const tdiv = this.tooltip
+
+      tdiv.style.left = b1.left - b2.left + 'px'
+      this.lineDiv.appendChild(tdiv)
+
+      const b3 = tdiv.getBoundingClientRect()
+      const top = b1.top - b2.top - b3.height - yOffset
+      if (top < 0) {
+        tdiv.style.top = b1.top - b2.top + b1.height + yOffset + 'px'
+      } else {
+        tdiv.style.top = top + 'px'
+      }
+    }
+  }
+
+  CodeMirror.defineOption('hyperlink', true, (cm) => {
+    const addon = new HyperLink(cm)
+  })
+}

--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -259,6 +259,13 @@ class FSNoteDb implements NoteDb {
     await unlinkFile(attachmentPathname)
   }
 
+  async copyNoteLink(noteId: string, noteProps: Partial<NoteDocEditibleProps>) {
+    const noteLink = `[${escapeRegExp(
+      noteProps.title ? noteProps.title : 'Untitled'
+    )}](:${noteId})`
+    return noteLink
+  }
+
   async createNote(
     noteProps: Partial<NoteDocEditibleProps | NoteDocImportableProps>
   ) {

--- a/src/lib/db/PouchNoteDb.ts
+++ b/src/lib/db/PouchNoteDb.ts
@@ -405,6 +405,13 @@ export default class PouchNoteDb implements NoteDb {
     })
   }
 
+  async copyNoteLink(noteId: string, noteProps: Partial<NoteDocEditibleProps>) {
+    const noteLink = `[${escapeRegExp(
+      noteProps.title ? noteProps.title : 'Untitled'
+    )}](:${noteId})`
+    return noteLink
+  }
+
   async trashNote(noteId: string): Promise<NoteDoc> {
     const note = await this.getNote(noteId)
     if (note == null)

--- a/src/lib/db/consts.ts
+++ b/src/lib/db/consts.ts
@@ -2,3 +2,5 @@ export const FOLDER_ID_PREFIX = 'folder:'
 export const NOTE_ID_PREFIX = 'note:'
 export const TAG_ID_PREFIX = 'tag:'
 export const ATTACHMENTS_ID = 'attachments'
+export const NOTE_LINK_SHORT_ID_REGEXP = /^[a-zA-Z0-9_\-]{7,14}$/
+export const NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP = /\((:note:)([a-zA-Z0-9_\-]{7,14})\)/g

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -1,4 +1,10 @@
-import { NOTE_ID_PREFIX, FOLDER_ID_PREFIX, TAG_ID_PREFIX } from './consts'
+import {
+  NOTE_ID_PREFIX,
+  FOLDER_ID_PREFIX,
+  TAG_ID_PREFIX,
+  NOTE_LINK_SHORT_ID_REGEXP,
+  NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP,
+} from './consts'
 import { join } from 'path'
 import {
   ObjectMap,
@@ -39,9 +45,20 @@ export function excludeFileProtocol(src: string) {
 
 export function prependNoteIdPrefix(noteId: string): string {
   if (new RegExp(`^${NOTE_ID_PREFIX}`).test(noteId)) {
-    return `${NOTE_ID_PREFIX}${noteId}`
+    return noteId
   }
-  return noteId
+  return `${NOTE_ID_PREFIX}${noteId}`
+}
+
+export function isNoteLinkId(href: string): boolean {
+  return NOTE_LINK_SHORT_ID_REGEXP.test(href)
+}
+
+export function removePrefixFromNoteLinks(content: string): string {
+  if (NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP.test(content)) {
+    return content.replace(NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP, '($2)')
+  }
+  return content
 }
 
 export function getFolderId(pathname: string): string {

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,3 +1,16 @@
+export function getNoteFullItemId(
+  storageId: string,
+  pathname: string,
+  noteId: string
+) {
+  const notePathname = pathname.startsWith('/')
+    ? pathname.substring(1)
+    : pathname
+  return `/app/storages/${storageId}/notes/${notePathname}${
+    notePathname === '' ? '' : '/'
+  }note:${noteId}`
+}
+
 export function getStorageItemId(storageId: string) {
   return `storage:${storageId}`
 }

--- a/static/main-preload.js
+++ b/static/main-preload.js
@@ -165,6 +165,7 @@
   function isDefaultProtocolClient(protocol) {
     return electron.remote.app.isDefaultProtocolClient(protocol)
   }
+
   function getWebContentsById(id) {
     return electron.remote.webContents.fromId(id)
   }
@@ -239,7 +240,7 @@
   window.__ELECTRON_ONLY__.setAsDefaultProtocolClient = setAsDefaultProtocolClient
   window.__ELECTRON_ONLY__.removeAsDefaultProtocolClient = removeAsDefaultProtocolClient
   window.__ELECTRON_ONLY__.isDefaultProtocolClient = isDefaultProtocolClient
-  window.__ELECTRON_ONLY__.getWebContentsById
+  window.__ELECTRON_ONLY__.getWebContentsById = getWebContentsById
   window.__ELECTRON_ONLY__.setTrafficLightPosition = setTrafficLightPosition
   window.__ELECTRON_ONLY__.convertHtmlStringToPdfBuffer = convertHtmlStringToPdfBuffer
   window.__ELECTRON_ONLY__.setCookie = setCookie

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.ts", "src/**/*.tsx", "typings/**/*.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "typings/**/*.d.ts", "src/lib/addons/*.js"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
**Add note-link functionality (#313)**

Add copy note link menu option (NoteItem.tsx)
Update db API for creating a note link (createstore, FSNoteDb, PouchNoteDb)
Add codemirror hyperlink addon
Add codemirror hyperlink addon css style (CodeEditor.tsx)
Initialize hyperlink addon (CodeMirror.ts)
Add event handling of editor ctrl+click link with ipc (App.tsx)
Add regexes for note link shortId (MarkdownPreviewer.tsx)
Add handling of rendering and clicking of note link in md preview
Fix invalid logic in prependNoteIdPrefix (should return prefixed noteId when no prefix is found)

**Fix electron only API**
Fix getWebContentsById to be initialized
Fix hyperlink to use electron only API
Fix macos binding in hyperlink

Copy link option:
![CopyNoteLink](https://user-images.githubusercontent.com/18196945/99583026-30ebb200-29e3-11eb-95ce-e6d4a13eaf51.png)

Hovering over note link inside editor:
![EditorNoteLinkPopup](https://user-images.githubusercontent.com/18196945/99583047-3a751a00-29e3-11eb-9bf2-ec4789556630.png)

Hovering  on note link in markdown preview:
![HoverOnLinkMd](https://user-images.githubusercontent.com/18196945/99583066-4234be80-29e3-11eb-94b3-7f5059ae48f1.png)

**Test:** 
In electron Linux App (dev)
In electron Linux App production version (appImage)

Improvements:

 -  [ ] See if we can use similar logic as linkify-remark to get links and then remove our prefixes (:note: etc) instead of directly removing note content for md preview to be able to consider it a link
  - [ ] Style the md preview link better 
  - [x] Add note link copied message
  - [x] Add status in status bar (when comes) that something is in clipboard
  - [ ] Add better export (how to handle?) of links to another note

