### PR TITLE
Homepage Typo fix

### DIFF
--- a/homepage/locales/en.ts
+++ b/homepage/locales/en.ts
@@ -34,10 +34,10 @@ export default {
         'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       feature2Name: 'Create Diagrams Like a Pro',
       feature2Detail:
-        'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+        'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       feature3Name: 'Beautiful Mathematical Script',
       feature3Detail:
-        'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+        'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       title: 'Features',

--- a/homepage/locales/fr.ts
+++ b/homepage/locales/fr.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       title: 'Fonctionnalités',

--- a/homepage/locales/hr.ts
+++ b/homepage/locales/hr.ts
@@ -32,7 +32,7 @@ export default {
           'Dostupna je podrška za Charts.js, Mermaid i PlantUML, što znači da u dokument možete staviti dijagrame.',
         feature3Name: 'Prekrasan prikaz matematičkih bilježaka',
         feature3Detail:
-          'Za preglednu reprezentaciju matematičkih jednadžbi, vrijeme je da koristite LaTex unutar vašeg Boost Hub uređivača.',
+          'Za preglednu reprezentaciju matematičkih jednadžbi, vrijeme je da koristite LaTeX unutar vašeg Boost Hub uređivača.',
       },
       features: {
         title: 'Značajke',

--- a/homepage/locales/ja.ts
+++ b/homepage/locales/ja.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       // title: 'Features',

--- a/homepage/locales/ko.ts
+++ b/homepage/locales/ko.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       // title: 'Features',

--- a/homepage/locales/nl.ts
+++ b/homepage/locales/nl.ts
@@ -33,7 +33,7 @@ export default {
       feature2Name: 'Real-time Samenwerken',
       feature2Detail: 'Bewerk documenten gelijktijdig met teamleden',
       feature3Name: 'Veelzijdige Markdown',
-      feature3Detail: 'Ondersteund LaTex, PlantUML, enz.',
+      feature3Detail: 'Ondersteund LaTeX, PlantUML, enz.',
       feature4Name: 'Sneltoetsen',
       feature4Detail: 'Meer dan 20 sneltoetsen beschikbaar',
     },

--- a/homepage/locales/pt.ts
+++ b/homepage/locales/pt.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       // title: 'Features',

--- a/homepage/locales/ptBR.ts
+++ b/homepage/locales/ptBR.ts
@@ -37,7 +37,7 @@ export default {
           'Suporta Charts.js, Mermaid, e PlantUML, ou seja, você pode incluir diagramas no seu documento.',
         feature3Name: 'Linguagem Matemática Elegante',
         feature3Detail:
-          'Para uma representação clara de equações matemáticas, utilize LaTex no editor do Boost Hub.'
+          'Para uma representação clara de equações matemáticas, utilize LaTeX no editor do Boost Hub.'
       },
       features: {
         title: 'Recursos',
@@ -97,4 +97,3 @@ export default {
       },
     },
   }
-  

--- a/homepage/locales/ru.ts
+++ b/homepage/locales/ru.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       // title: 'Features',

--- a/homepage/locales/vn.ts
+++ b/homepage/locales/vn.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       title: 'Các chức năng',

--- a/homepage/locales/zh.ts
+++ b/homepage/locales/zh.ts
@@ -34,10 +34,10 @@ export default {
       //   'Write and edit documents as a team and sharing your knowledge and ideas in real-time. No one will be left behind.',
       // feature2Name: 'Create Diagrams Like a Pro',
       // feature2Detail:
-      //   'Supports Charts.js, Mermaid, andPlantUML, which means you can put diagrams in your document.',
+      //   'Supports Charts.js, Mermaid, and PlantUML, which means you can put diagrams in your document.',
       // feature3Name: 'Beautiful Mathematical Script',
       // feature3Detail:
-      //   'For clean representation of maths equations it is time to use LaTex in the Boost Hub editor.',
+      //   'For clean representation of maths equations it is time to use LaTeX in the Boost Hub editor.',
     },
     features: {
       // title: 'Features',


### PR DESCRIPTION
Typo fixes for Homepage.

For spanisch (#677) and german (#692) are separate PR available