### PR TITLE
Initialize StorageMap after importing from legacy (#667)

### DIFF
--- a/src/components/organisms/ImportLegacyNotesForm.tsx
+++ b/src/components/organisms/ImportLegacyNotesForm.tsx
@@ -30,7 +30,7 @@ interface ImportLegacyNotesFormProps {
 }
 
 const ImportLegacyNotesForm = ({ storageId }: ImportLegacyNotesFormProps) => {
-  const { addAttachments, createFolder, createNote } = useDb()
+  const { addAttachments, createFolder, createNote, initialize } = useDb()
 
   const [location, setLocation] = useState('')
   const [opened, setOpened] = useState(false)
@@ -221,7 +221,9 @@ const ImportLegacyNotesForm = ({ storageId }: ImportLegacyNotesFormProps) => {
             : ''
         }`
       )
-      setOpened(false)
+      initialize().then(() => {
+        setOpened(false)
+      })
     } catch (error) {
       setErrorMessage(error.message)
       console.error(error)
@@ -236,6 +238,7 @@ const ImportLegacyNotesForm = ({ storageId }: ImportLegacyNotesFormProps) => {
     createFolder,
     createNote,
     importing,
+    initialize,
   ])
 
   const updateConvertingSnippetNotes = useCallback(


### PR DESCRIPTION
Fixes #667.

`setState()` call in React runs asynchronously, making the `setStorageMap()` call inside `createFolder()` and `createNote()` asynchronous. React will batch these updates together, making value of `storageMap` is unreliable inside `createNote()`, which depends on the updates from `createFolder()` when importing legacy notes.

Calling `initialize()` will restore the `storageMap()` by repopulating `folderMap` and `noteMap`.