### PR TITLE
Add tag colors setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2275,8 +2275,7 @@
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "dev": true
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -9488,7 +9487,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.4.tgz",
       "integrity": "sha512-EswbYJDF1kkrx93/YU+BbBtb46CCtDMvTiGmcOa/c5PETnwTiSWoseJ1oSWeRl/4rUXkhME9bVURvvPg0W5YQw==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "@types/reactcss": "*"
@@ -9542,7 +9540,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-d2gQQ0IL6hXLnoRfVYZukQNWHuVsE75DzFTLPUuyyEhJS8G2VvlE+qfQQ91SJjaMqlURRCNIsX7Jcsw6cEuJlA==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -23387,8 +23384,7 @@
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
-      "dev": true
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -23578,8 +23574,7 @@
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "dev": true
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -26062,7 +26057,6 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
       "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.15",
@@ -26633,7 +26627,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "dev": true,
       "requires": {
         "lodash": "^4.0.1"
       }
@@ -29683,8 +29676,7 @@
     "tinycolor2": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-      "dev": true
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   "dependencies": {
     "@mdi/js": "^5.8.55",
     "@mdi/react": "^1.2.1",
+    "@types/react-color": "^3.0.4",
     "aws-amplify": "^1.2.4",
     "classcat": "^4.0.2",
     "codemirror": "^5.58.2",
@@ -156,6 +157,7 @@
     "ramda": "^0.26.1",
     "raw-loader": "^4.0.0",
     "react": "^16.9.0",
+    "react-color": "^2.19.3",
     "react-dom": "^16.9.0",
     "react-i18next": "^11.0.1",
     "react-use": "^12.10.0",

--- a/src/components/atoms/TagNavigatorListItem.tsx
+++ b/src/components/atoms/TagNavigatorListItem.tsx
@@ -1,38 +1,57 @@
-import React from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import Icon from './Icon'
 import styled from '../../lib/styled'
 import { mdiClose } from '@mdi/js'
-import { flexCenter } from '../../lib/styled/styleFunctions'
+import {
+  flexCenter,
+  tagBackgroundColor,
+  TagStyleProps,
+} from '../../lib/styled/styleFunctions'
 import { useRouter } from '../../lib/router'
 import { useTranslation } from 'react-i18next'
-import { useAnalytics, analyticsEvents } from '../../lib/analytics'
+import { analyticsEvents, useAnalytics } from '../../lib/analytics'
+import DialogColorPicker from './dialog/DialogColorPicker'
+import { PopulatedTagDoc } from '../../lib/db/types'
+import { BaseTheme } from '../../lib/styled/BaseTheme'
+import { isColorBright } from '../../lib/colors'
+import { tagItemHeightSize } from './dialog/styled'
 
-const TagItem = styled.li`
-  margin-right: 5px;
-  height: 18px;
-  font-size: 14px;
-  ${flexCenter}
-  background-color: ${({ theme }) => theme.secondaryBackgroundColor};
+const TagItem = styled.li<BaseTheme & TagStyleProps>`
   border-radius: 9px;
   white-space: nowrap;
+  position: relative;
+  ${tagBackgroundColor};
+
+  margin-right: 5px;
+  height: ${tagItemHeightSize};
+  font-size: 14px;
+  ${flexCenter};
 `
 
-const TagItemAnchor = styled.button`
+const TagItemAnchor = styled.button<BaseTheme & TagStyleProps>`
   background-color: transparent;
   border: none;
   cursor: pointer;
   padding-left: 0.75em;
   text-decoration: none;
-  color: ${({ theme }) => theme.textColor};
+  color: #fff;
+  filter: invert(
+    ${({ theme, color }) =>
+      isColorBright(color || theme.secondaryBackgroundColor) ? 100 : 0}%
+  );
 `
 
-const TagRemoveButton = styled.button`
+const TagRemoveButton = styled.button<BaseTheme & TagStyleProps>`
   background-color: transparent;
   cursor: pointer;
   padding: 0 0.25em;
   border: none;
   transition: color 200ms ease-in-out;
-  color: ${({ theme }) => theme.textColor};
+  color: #fff;
+  filter: invert(
+    ${({ theme, color }) =>
+      isColorBright(color || theme.secondaryBackgroundColor) ? 100 : 0}%
+  );
   width: 24px;
   height: 24px;
   ${flexCenter}
@@ -40,10 +59,11 @@ const TagRemoveButton = styled.button`
 
 interface TagNavigatorListItemProps {
   storageId: string
-  tag: string
+  tag: PopulatedTagDoc
   noteId?: string
   currentTagName: string | null
   removeTagByName: (tagName: string) => void
+  updateTagColorByName: (tagName: string, color: string) => void
 }
 
 const TagNavigatorListItem = ({
@@ -52,36 +72,68 @@ const TagNavigatorListItem = ({
   noteId,
   currentTagName,
   removeTagByName,
+  updateTagColorByName,
 }: TagNavigatorListItemProps) => {
   const { t } = useTranslation()
   const { push } = useRouter()
   const { report } = useAnalytics()
 
+  const [colorPickerModal, showColorPickerModal] = useState(false)
+
+  const openTagContextMenu = useCallback(() => {
+    showColorPickerModal(true)
+  }, [showColorPickerModal])
+
+  const handleColorChangeComplete = useCallback(
+    (newColor: string) => {
+      showColorPickerModal(false)
+      tag.data.color = newColor
+      updateTagColorByName(tag.name, tag.data.color)
+    },
+    [tag, updateTagColorByName]
+  )
+  const tagColor = useMemo(() => {
+    return tag.data.color
+      ? typeof tag.data.color == 'string'
+        ? tag.data.color
+        : ''
+      : ''
+  }, [tag.data.color])
   return (
-    <TagItem>
-      <TagItemAnchor
-        title={`#${tag}`}
-        onClick={() => {
-          if (noteId == null) {
-            push(`/app/storages/${storageId}/tags/${tag}`)
-            return
-          }
-          push(`/app/storages/${storageId}/tags/${tag}/${noteId}`)
-        }}
-        className={currentTagName === tag ? 'active' : ''}
-      >
-        {tag}
-      </TagItemAnchor>
-      <TagRemoveButton
-        title={t('tag.removeX', { tag })}
-        onClick={() => {
-          removeTagByName(tag)
-          report(analyticsEvents.removeNoteTag)
-        }}
-      >
-        <Icon path={mdiClose} />
-      </TagRemoveButton>
-    </TagItem>
+    <>
+      {colorPickerModal && (
+        <DialogColorPicker
+          initialColor={tagColor}
+          handleChangeComplete={handleColorChangeComplete}
+        />
+      )}
+      <TagItem color={tagColor} onContextMenu={openTagContextMenu}>
+        <TagItemAnchor
+          color={tagColor}
+          title={`#${tag.name}`}
+          onClick={() => {
+            if (noteId == null) {
+              push(`/app/storages/${storageId}/tags/${tag.name}`)
+              return
+            }
+            push(`/app/storages/${storageId}/tags/${tag.name}/${noteId}`)
+          }}
+          className={currentTagName === tag.name ? 'active' : ''}
+        >
+          {tag.name}
+        </TagItemAnchor>
+        <TagRemoveButton
+          color={tagColor}
+          title={t('tag.removeX', { tag: tag.name })}
+          onClick={() => {
+            removeTagByName(tag.name)
+            report(analyticsEvents.removeNoteTag)
+          }}
+        >
+          <Icon path={mdiClose} />
+        </TagRemoveButton>
+      </TagItem>
+    </>
   )
 }
 

--- a/src/components/atoms/TagNavigatorNewTagPopup.tsx
+++ b/src/components/atoms/TagNavigatorNewTagPopup.tsx
@@ -38,7 +38,7 @@ const Container = styled.div`
 `
 
 const TagNameInput = styled.input`
-  ${inputStyle}
+  ${inputStyle};
   width: 100%;
   height: 30px;
   padding: 0 0.25em;

--- a/src/components/atoms/dialog/DialogColorPicker.tsx
+++ b/src/components/atoms/dialog/DialogColorPicker.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useState } from 'react'
+import { SketchPicker, ColorResult } from 'react-color'
+import {
+  DialogColorPickerPopover,
+  DialogColorPickerCover,
+  DialogColorPickerContainer,
+} from './styled'
+import { defaultTagColor } from '../../../lib/colors'
+
+type ColorPickerProps = {
+  handleChangeComplete: (color: string) => void
+  initialColor?: string
+}
+
+const DialogColorPicker = ({
+  handleChangeComplete,
+  initialColor,
+}: ColorPickerProps) => {
+  const [color, setColor] = useState(
+    initialColor ? initialColor : defaultTagColor
+  )
+
+  const handleChange = useCallback((color: ColorResult) => {
+    setColor(color.hex)
+  }, [])
+
+  return (
+    <DialogColorPickerContainer>
+      <DialogColorPickerPopover>
+        <DialogColorPickerCover onClick={() => handleChangeComplete(color)} />
+        <SketchPicker
+          disableAlpha={true}
+          color={color}
+          onChange={handleChange}
+        />
+      </DialogColorPickerPopover>
+    </DialogColorPickerContainer>
+  )
+}
+
+export default DialogColorPicker

--- a/src/components/atoms/dialog/styled.ts
+++ b/src/components/atoms/dialog/styled.ts
@@ -5,6 +5,7 @@ import {
   inputStyle,
   secondaryButtonStyle,
 } from '../../../lib/styled/styleFunctions'
+import { getColorBrightness } from '../../../lib/colors'
 
 const dialogZIndex = 8000
 
@@ -75,4 +76,62 @@ export const DialogButton = styled.button`
   margin-left: 8px;
   user-select: none;
   ${secondaryButtonStyle}
+`
+
+export const tagItemHeightSize = `18px`
+
+export const DialogColorPickerContainer = styled.div`
+  display: flex;
+  margin-top: ${tagItemHeightSize};
+  z-index: 6000;
+`
+
+export const DialogColorMessage = styled.p`
+  margin: auto 0;
+`
+
+export const DialogColorPickerButton = styled.button`
+  width: 64px;
+  margin-left: 8px;
+  border: none;
+  border-radius: 2px;
+  background-color: rgba(0, 0, 0, 0.12);
+  display: inline-block;
+  cursor: pointer;
+`
+
+export const DialogColorPreview = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 32px;
+  border-radius: 2px;
+  color: ${({ theme }) =>
+    getColorBrightness(theme.backgroundColor) > 125 ? 'black' : 'white'};
+`
+
+export const DialogColorIndicator = styled.p`
+  margin: auto;
+`
+
+interface DialogColorPickerPopoverLocationProps {
+  offsetLeft: number
+}
+
+export const DialogColorPickerPopover = styled.div<
+  DialogColorPickerPopoverLocationProps
+>`
+  position: absolute;
+  z-index: 6000;
+  .sketch-picker {
+    margin-top: 3px;
+  }
+`
+
+export const DialogColorPickerCover = styled.div`
+  position: fixed;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
 `

--- a/src/components/molecules/FolderNavigatorItem.tsx
+++ b/src/components/molecules/FolderNavigatorItem.tsx
@@ -112,6 +112,7 @@ const FolderNavigatorItem = ({
   const openFolderContextMenu = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault()
+      event.stopPropagation()
       openContextMenu({
         menuItems: [
           {

--- a/src/components/molecules/NoteDetailTagNavigator.tsx
+++ b/src/components/molecules/NoteDetailTagNavigator.tsx
@@ -8,6 +8,7 @@ import ToolbarIconButton from '../atoms/ToolbarIconButton'
 import TagNavigatorListItem from '../atoms/TagNavigatorListItem'
 import TagNavigatorNewTagPopup from '../atoms/TagNavigatorNewTagPopup'
 import { useTranslation } from 'react-i18next'
+import { PopulatedTagDoc } from '../../lib/db/types'
 
 const Container = styled.div`
   display: flex;
@@ -20,7 +21,7 @@ const Container = styled.div`
 const IconContainer = styled.div`
   width: 24px;
   height: 24px;
-  ${flexCenter}
+  ${flexCenter};
   background-color: transparent;
   border: none;
   color: ${({ theme }) => theme.navButtonColor};
@@ -35,11 +36,12 @@ const TagNavigatorList = styled.ul`
 
 interface NoteDetailTagNavigatorProps {
   storageId: string
-  storageTags: string[]
+  storageTags: PopulatedTagDoc[]
   noteId?: string
   tags: string[]
   appendTagByName: (tagName: string) => void
   removeTagByName: (tagName: string) => void
+  updateTagColorByName: (tagName: string, color: string) => void
 }
 
 const NoteDetailTagNavigator = ({
@@ -49,6 +51,7 @@ const NoteDetailTagNavigator = ({
   tags,
   appendTagByName,
   removeTagByName,
+  updateTagColorByName,
 }: NoteDetailTagNavigatorProps) => {
   const { t } = useTranslation()
 
@@ -82,6 +85,12 @@ const NoteDetailTagNavigator = ({
     }
   }, [setNewTagPopupPosition])
 
+  const noteTags = useMemo(() => {
+    return tags.map((tagName) =>
+      storageTags.find((storageTag) => storageTag.name == tagName)
+    )
+  }, [tags, storageTags])
+
   useEffect(() => {
     const resizeHandler = () => {
       if (newTagPopupPosition == null) {
@@ -102,16 +111,19 @@ const NoteDetailTagNavigator = ({
           <Icon path={mdiTagMultiple} />{' '}
         </IconContainer>
         <TagNavigatorList>
-          {tags.map((tag) => {
+          {noteTags.map((tag) => {
             return (
-              <TagNavigatorListItem
-                key={tag}
-                storageId={storageId}
-                noteId={noteId}
-                currentTagName={currentTagName}
-                tag={tag}
-                removeTagByName={removeTagByName}
-              />
+              tag && (
+                <TagNavigatorListItem
+                  key={tag.name}
+                  storageId={storageId}
+                  noteId={noteId}
+                  currentTagName={currentTagName}
+                  tag={tag}
+                  removeTagByName={removeTagByName}
+                  updateTagColorByName={updateTagColorByName}
+                />
+              )
             )
           })}
         </TagNavigatorList>
@@ -126,7 +138,7 @@ const NoteDetailTagNavigator = ({
         <TagNavigatorNewTagPopup
           position={newTagPopupPosition}
           tags={tags}
-          storageTags={storageTags}
+          storageTags={storageTags.map((tagDetail) => tagDetail.name)}
           close={closeNewTagPopup}
           appendTagByName={appendTagByName}
         />

--- a/src/components/molecules/StorageNavigatorFragment.tsx
+++ b/src/components/molecules/StorageNavigatorFragment.tsx
@@ -193,6 +193,7 @@ const StorageNavigatorFragment = ({
   const openWorkspaceContextMenu: MouseEventHandler = useCallback(
     (event) => {
       event.preventDefault()
+      event.stopPropagation()
       const contentMenuItems: MenuItemConstructorOptions[] = [
         {
           type: 'normal',

--- a/src/components/molecules/TagListFragment.tsx
+++ b/src/components/molecules/TagListFragment.tsx
@@ -81,6 +81,7 @@ const TagListItem = ({ tagName, storageId }: TagListItemProps) => {
   const openTagContextMenu = useCallback(
     (event: React.MouseEvent<Element, MouseEvent>) => {
       event.preventDefault()
+      event.stopPropagation()
       openContextMenu({
         menuItems: [
           {

--- a/src/components/organisms/NoteListNavigator.tsx
+++ b/src/components/organisms/NoteListNavigator.tsx
@@ -5,7 +5,7 @@ import { borderBottom } from '../../lib/styled/styleFunctions'
 import { useTranslation } from 'react-i18next'
 import { isWithGeneralCtrlKey } from '../../lib/keyboard'
 import { osName } from '../../lib/platform'
-import { NoteDoc } from '../../lib/db/types'
+import { NoteDoc, PopulatedTagDoc } from '../../lib/db/types'
 import { NoteSortingOptions } from '../../lib/sort'
 import NoteSortingOptionsFragment from '../molecules/NoteSortingOptionsFragment'
 import { usePreferences } from '../../lib/preferences'
@@ -50,6 +50,7 @@ const NoteList = styled.ul`
 `
 
 type NoteListNavigatorProps = {
+  storageTags: PopulatedTagDoc[]
   storageId: string
   currentNote?: NoteDoc
   currentNoteIndex: number
@@ -70,6 +71,7 @@ const NoteListNavigator = ({
   noteSorting,
   setNoteSorting,
   createNote,
+  storageTags,
   storageId,
   basePathname,
   trashNote,
@@ -205,10 +207,22 @@ const NoteListNavigator = ({
       >
         {notes.map((note) => {
           const noteIsCurrentNote = note._id === currentNote?._id
-
+          const noteTags = note.tags.reduce(
+            (result: PopulatedTagDoc[], tagName) => {
+              const tagElement = storageTags.find(
+                (storageTag) => storageTag.name == tagName
+              )
+              if (tagElement !== undefined) {
+                result.push(tagElement)
+              }
+              return result
+            },
+            []
+          )
           return (
             <li key={note._id}>
               <NoteItem
+                noteTags={noteTags}
                 storageId={storageId}
                 active={noteIsCurrentNote}
                 note={note}

--- a/src/components/organisms/NotePageToolbar.tsx
+++ b/src/components/organisms/NotePageToolbar.tsx
@@ -22,7 +22,7 @@ import { useGeneralStatus } from '../../lib/generalStatus'
 import ToolbarSeparator from '../atoms/ToolbarSeparator'
 import NotePageToolbarNoteHeader from '../molecules/NotePageToolbarNoteHeader'
 import NoteDetailTagNavigator from '../molecules/NoteDetailTagNavigator'
-import { values, isTagNameValid } from '../../lib/db/utils'
+import { isTagNameValid, values } from '../../lib/db/utils'
 import {
   exportNoteAsHtmlFile,
   exportNoteAsMarkdownFile,
@@ -87,6 +87,7 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
     untrashNote,
     bookmarkNote,
     unbookmarkNote,
+    updateTagByName,
   } = useDb()
   const { report } = useAnalytics()
   const { setPreferences, preferences } = usePreferences()
@@ -173,6 +174,28 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
     [storage.id, note, updateNote]
   )
 
+  const storageTags = useMemo(() => {
+    if (storage == null) return []
+    return [...values(storage.tagMap)]
+  }, [storage])
+
+  const updateTagColorByName = useCallback(
+    async (tagName: string, color: string) => {
+      if (note == null || tagName == null) {
+        // Notify user of failed tag color update
+        pushMessage({
+          title: 'Cannot update tag color.',
+          description: 'Invalid note or tag.',
+        })
+        return
+      }
+      await updateTagByName(storage.id, tagName, {
+        data: { color: color },
+      })
+    },
+    [storage.id, note, updateTagByName, pushMessage]
+  )
+
   const getAttachmentData = useCallback(
     async (src: string) => {
       if (note == null) {
@@ -186,11 +209,6 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
     },
     [note, storage.attachmentMap]
   )
-
-  const storageTags = useMemo(() => {
-    if (storage == null) return []
-    return values(storage.tagMap).map((tag) => tag.name)
-  }, [storage])
 
   const selectEditMode = useCallback(() => {
     setGeneralStatus({
@@ -556,6 +574,7 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
           tags={note.tags}
           appendTagByName={appendTagByName}
           removeTagByName={removeTagByName}
+          updateTagColorByName={updateTagColorByName}
         />
       )}
     </>

--- a/src/components/organisms/NoteStorageNavigator.tsx
+++ b/src/components/organisms/NoteStorageNavigator.tsx
@@ -85,6 +85,7 @@ const NoteStorageNavigator = ({ storage }: NoteStorageNavigatorProps) => {
   const openStorageContextMenu = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault()
+      event.stopPropagation()
 
       const storages = values(storageMap)
       openContextMenu({

--- a/src/components/organisms/SearchModal.tsx
+++ b/src/components/organisms/SearchModal.tsx
@@ -379,7 +379,7 @@ const Container = styled.div<BaseTheme & TextAreaProps>`
     position: relative;
     margin: 50px auto 0;
     background-color: ${({ theme }) => theme.navBackgroundColor};
-    width: calc(100% -15px);
+    width: calc(100% - 15px);
     max-width: 720px;
     overflow: hidden;
     z-index: 6002;
@@ -494,7 +494,7 @@ const EditorPreview = styled.div`
       padding: 0 5px;
 
       background-color: transparent;
-      ${flexCenter}
+      ${flexCenter};
 
       border: none;
       cursor: pointer;

--- a/src/components/pages/NotePage.tsx
+++ b/src/components/pages/NotePage.tsx
@@ -201,6 +201,11 @@ const NotePage = ({ storage }: NotePageProps) => {
 
   const { showSearchModal } = useSearchModal()
 
+  const storageTags = useMemo(() => {
+    if (storage == null) return []
+    return [...values(storage.tagMap)]
+  }, [storage])
+
   return (
     <StorageLayout storage={storage}>
       {showSearchModal && <SearchModal storage={storage} />}
@@ -212,6 +217,7 @@ const NotePage = ({ storage }: NotePageProps) => {
           left={
             <NoteListNavigator
               storageId={storage.id}
+              storageTags={storageTags}
               notes={sortedNotes}
               currentNoteIndex={currentNoteIndex}
               noteSorting={preferences['general.noteSorting']}

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,8 +1,4 @@
-interface RGBColor {
-  r: number
-  g: number
-  b: number
-}
+import { RGBColor } from 'react-color'
 
 export function convertHexStringToRgbString(hex: string): RGBColor {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
@@ -20,8 +16,9 @@ export function convertHexStringToRgbString(hex: string): RGBColor {
 }
 
 const brightnessDefaultThreshold = 110
+export const defaultTagColor = '#ffffff'
 
-export function getColorBrightness(color: RGBColor | string) {
+export function getColorBrightness(color: RGBColor | string): number {
   if (color == '') {
     return 0
   }
@@ -35,6 +32,6 @@ export function getColorBrightness(color: RGBColor | string) {
 export function isColorBright(
   color: RGBColor | string,
   threshold: number = brightnessDefaultThreshold
-) {
+): boolean {
   return getColorBrightness(color) > threshold
 }

--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -444,6 +444,14 @@ class FSNoteDb implements NoteDb {
     return tagDoc
   }
 
+  async updateTagByName(
+    tagName: string,
+    props?: Partial<TagDocEditibleProps>
+  ): Promise<void> {
+    await this.upsertTag(tagName, props)
+    await this.saveBoostNoteJSON()
+  }
+
   async removeTag(tagName: string): Promise<void> {
     const notes = await this.loadAllNotes()
     const notesWithTags = notes.filter((note) => {

--- a/src/lib/db/PouchNoteDb.ts
+++ b/src/lib/db/PouchNoteDb.ts
@@ -508,6 +508,13 @@ export default class PouchNoteDb implements NoteDb {
     await this.pouchDb.remove(note)
   }
 
+  async updateTagByName(
+    tagName: string,
+    props?: Partial<TagDocEditibleProps>
+  ): Promise<void> {
+    await this.upsertTag(tagName, props)
+  }
+
   async removeTag(tagName: string): Promise<void> {
     const notes = await this.findNotesByTag(tagName)
     await Promise.all(
@@ -520,7 +527,7 @@ export default class PouchNoteDb implements NoteDb {
 
     const tag = await this.getTag(tagName)
     if (tag != null) {
-      this.pouchDb.remove(tag as any)
+      await this.pouchDb.remove(tag as any)
     }
   }
 

--- a/src/lib/styled/styleFunctions.ts
+++ b/src/lib/styled/styleFunctions.ts
@@ -1,7 +1,12 @@
 import { BaseTheme } from './BaseTheme'
+import { isColorBright } from '../colors'
 
 interface StyledProps {
   theme: BaseTheme
+}
+
+export interface TagStyleProps {
+  color: string
 }
 
 export const backgroundColor = ({ theme }: StyledProps) =>
@@ -199,3 +204,17 @@ export const flexCenter = () => `display: flex;
 align-items: center;
 justify-content: center;
 `
+
+export const tagBackgroundColor = ({
+  theme,
+  color,
+}: StyledProps & TagStyleProps) => `
+background-color: ${color || theme.secondaryBackgroundColor};
+  &:hover {
+    filter: brightness(${
+      isColorBright(color || theme.secondaryBackgroundColor) ? 85 : 115
+    }%
+    );
+    background-color: ${color || theme.secondaryBackgroundColor};
+  }
+}`


### PR DESCRIPTION
Add tag colors setup (#323):
- Add tag context menu (right click on tag) for chosing colors
- Add react color as color pickers library
- Add basic DB management for tags with color (FSNote, PouchDB, createStore API)
- Add basic UI component (react-color) for choosing the color
- Add basic handling of color brightness in tags and hover styles (black/white inversion, brigther, dimmer when bg is dark/light)
- Add colored tags inside note list note tag list

Fix right click context menu in sidebar

How it works:
Users can right click on any tag in note tag list. The color picker comes up and on selection it changes colors (preview is below in color slider at right corner), below that are some predefined colors which can be clicked. Once user is satisfied with color, to close the dialog any click outside of the color picker will do. The color is then updated in UI acordingly.

For background colors which are too dark, hovering the tag will brighten it up, opposite works too.
For background colors which are too dark, text and remove tag button are light/white and vice versa.

The following image shows picking color:
![InstructionsTagsChosingColor](https://user-images.githubusercontent.com/18196945/100648986-0c2bfe80-3342-11eb-95de-b981b5c5d06a.png)

Some colored tags preview:
![ColoredTagsNotePreview](https://user-images.githubusercontent.com/18196945/100649027-206ffb80-3342-11eb-8227-343b2d74ba50.png)

![ColoredTagsNotePreview_Colored](https://user-images.githubusercontent.com/18196945/100648955-00d8d300-3342-11eb-98f1-ede62349befd.png)

v0.11.5 - new tag location examples:
![ColorChoser](https://user-images.githubusercontent.com/18196945/101239142-7697c280-36e5-11eb-8d33-fdc0317eb63b.png)
![ColorList](https://user-images.githubusercontent.com/18196945/101239144-77305900-36e5-11eb-8005-c02c9e8dc143.png)



Test:
- In electron Linux App (dev)
- In electron Linux App production version (appImage)

