### PR TITLE
Preserve Note Creation and Last Updated Times when Importing from Legacy (#631)

### DIFF
--- a/src/components/organisms/ImportLegacyNotesForm.tsx
+++ b/src/components/organisms/ImportLegacyNotesForm.tsx
@@ -19,7 +19,7 @@ import {
   readFileTypeFromBuffer,
 } from '../../lib/electronOnly'
 import { join } from 'path'
-import { NoteDocEditibleProps } from '../../lib/db/types'
+import { NoteDocImportableProps } from '../../lib/db/types'
 import { isFolderPathnameValid } from '../../lib/db/utils'
 import { useDb } from '../../lib/db'
 import { JsonObject } from 'type-fest'
@@ -112,6 +112,8 @@ const ImportLegacyNotesForm = ({ storageId }: ImportLegacyNotesFormProps) => {
           const title = normalizeString(note.title)
           const tags = normalizeTags(note.tags)
           const data = {}
+          const createdAt = normalizeString(note.createdAt)
+          const updatedAt = normalizeString(note.updatedAt)
           switch (note.type) {
             case 'MARKDOWN_NOTE': {
               const legacyNoteId = noteFileName.replace(/.cson$/, '')
@@ -164,12 +166,14 @@ const ImportLegacyNotesForm = ({ storageId }: ImportLegacyNotesFormProps) => {
                 )
               }
 
-              const noteProps: NoteDocEditibleProps = {
+              const noteProps: NoteDocImportableProps = {
                 folderPathname,
                 title,
                 content,
                 tags,
                 data,
+                createdAt,
+                updatedAt,
               }
               return noteProps
             }
@@ -186,12 +190,14 @@ const ImportLegacyNotesForm = ({ storageId }: ImportLegacyNotesFormProps) => {
                 .map(stringifySnippet)
                 .join('\n\n')}`
 
-              const noteProps: NoteDocEditibleProps = {
+              const noteProps: NoteDocImportableProps = {
                 folderPathname,
                 title,
                 content,
                 tags,
                 data,
+                createdAt,
+                updatedAt,
               }
               return noteProps
             }

--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -7,6 +7,7 @@ import {
   Attachment,
   FolderDocEditibleProps,
   NoteDocEditibleProps,
+  NoteDocImportableProps,
   TagDocEditibleProps,
   TagDoc,
   PopulatedFolderDoc,
@@ -257,7 +258,7 @@ class FSNoteDb implements NoteDb {
     await unlinkFile(attachmentPathname)
   }
 
-  async createNote(noteProps: Partial<NoteDocEditibleProps>) {
+  async createNote(noteProps: Partial<NoteDocEditibleProps | NoteDocImportableProps>) {
     const now = getNow()
     const noteDoc: NoteDoc = {
       _id: generateNoteId(),
@@ -266,9 +267,9 @@ class FSNoteDb implements NoteDb {
       tags: [],
       folderPathname: '/',
       data: {},
-      ...noteProps,
       createdAt: now,
       updatedAt: now,
+      ...noteProps,
       trashed: false,
       _rev: generateId(),
     }

--- a/src/lib/db/createStore.ts
+++ b/src/lib/db/createStore.ts
@@ -4,6 +4,7 @@ import {
   ObjectMap,
   NoteDoc,
   NoteDocEditibleProps,
+  NoteDocImportableProps,
   PopulatedFolderDoc,
   PopulatedTagDoc,
   Attachment,
@@ -262,7 +263,7 @@ export function createDbStoreCreator(
       [setStorageMap, syncStorage]
     )
     const createNote = useCallback(
-      async (storageId: string, noteProps: Partial<NoteDocEditibleProps>) => {
+      async (storageId: string, noteProps: Partial<NoteDocEditibleProps | NoteDocImportableProps>) => {
         const storage = storageMap[storageId]
         if (storage == null) {
           return

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -43,6 +43,11 @@ export type NoteDocEditibleProps = {
   data: JsonObject
 }
 
+export type NoteDocImportableProps = {
+  createdAt: string
+  updatedAt: string
+} & NoteDocEditibleProps
+
 export type NoteDoc = {
   _id: string
   createdAt: string


### PR DESCRIPTION
Fixes #631.

Currently we do not read `createdAt` or `updatedAt` props when importing notes from legacy.
Added `noteDocImportableProps` type, since adding `createdAt` and `updatedAt` props to `noteDocEditibleProps` doesn't sound right.

Changed `createNote` functions to accept either imported props or editable partial props.

Tested the following cases after importing notes from legacy:
- Confirmed the creation date and last update date are preserved.
- Confirmed that last update date is changed when I edit the note and save.
- Confirmed that I can create notes manually, and creation date and last update date are set to now.