### PR TITLE
Add attachment rendering in PDF and HTML

### DIFF
--- a/src/components/organisms/NotePageToolbar.tsx
+++ b/src/components/organisms/NotePageToolbar.tsx
@@ -162,6 +162,20 @@ const NotePageToolbar = ({
     [storage.id, note, updateNote]
   )
 
+  const getAttachmentData = useCallback(
+    async (src: string) => {
+      if (note == null) {
+        return
+      }
+      if (storage.attachmentMap[src] != undefined) {
+        return storage.attachmentMap[src]?.getData()
+      } else {
+        return Promise.reject('Attachment not in map.')
+      }
+    },
+    [note, storage.attachmentMap]
+  )
+
   const storageTags = useMemo(() => {
     if (storage == null) return []
     return values(storage.tagMap).map((tag) => tag.name)
@@ -205,6 +219,7 @@ const NotePageToolbar = ({
                 note,
                 preferences,
                 pushMessage,
+                getAttachmentData,
                 previewStyle
               ),
           },
@@ -216,6 +231,7 @@ const NotePageToolbar = ({
                 note,
                 preferences,
                 pushMessage,
+                getAttachmentData,
                 previewStyle
               ),
           },

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -13,15 +13,7 @@ export function downloadString(
   document.body.removeChild(anchor)
 }
 
-interface DownloadBlobCallback {
-  (): void
-}
-
-export function downloadBlob(
-  blob: Blob,
-  fileName: string,
-  callback?: DownloadBlobCallback
-) {
+export function downloadBlob(blob: Blob, fileName: string) {
   const anchor = document.createElement('a')
   anchor.style.display = 'none'
   document.body.appendChild(anchor)
@@ -30,9 +22,6 @@ export function downloadBlob(
   anchor.click()
   window.URL.revokeObjectURL(anchor.href)
   document.body.removeChild(anchor)
-  if (callback) {
-    callback()
-  }
 }
 
 export function getAppLinkFromUserAgent() {

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -13,7 +13,15 @@ export function downloadString(
   document.body.removeChild(anchor)
 }
 
-export function downloadBlob(blob: Blob, fileName: string) {
+interface DownloadBlobCallback {
+  (): void
+}
+
+export function downloadBlob(
+  blob: Blob,
+  fileName: string,
+  callback?: DownloadBlobCallback
+) {
   const anchor = document.createElement('a')
   anchor.style.display = 'none'
   document.body.appendChild(anchor)
@@ -22,6 +30,9 @@ export function downloadBlob(blob: Blob, fileName: string) {
   anchor.click()
   window.URL.revokeObjectURL(anchor.href)
   document.body.removeChild(anchor)
+  if (callback) {
+    callback()
+  }
 }
 
 export function getAppLinkFromUserAgent() {

--- a/src/lib/exports.ts
+++ b/src/lib/exports.ts
@@ -204,7 +204,7 @@ const generatePrintToPdfHTML = (
   `
 }
 
-const blobToBase64 = async (blob: Blob) => {
+async function convertBlobToBase64(blob: Blob) {
   const reader = new FileReader()
   reader.readAsDataURL(blob)
   return new Promise<string | ArrayBuffer | null>((resolve) => {
@@ -214,12 +214,12 @@ const blobToBase64 = async (blob: Blob) => {
   })
 }
 
-const updateNoteLinks = async (
+async function updateNoteLinks(
   content: string,
   pushMessage: (context: any) => any,
   getAttachmentData: (src: string) => Promise<undefined | AttachmentData>,
   htmlExport = false
-): Promise<[string, string[]]> => {
+): Promise<[string, string[]]> {
   // How name is stored:
   //  const fileName = `${dashify(name)}-${getHexatrigesimalString(time++)
   // todo: [komediruzecki-11/12/2020] Is regex correct,
@@ -263,7 +263,7 @@ const updateNoteLinks = async (
       } else if (imageData.blob) {
         if (htmlExport) {
           // Set url as base64 encoded image
-          const base64EncodedImage = await blobToBase64(imageData.blob)
+          const base64EncodedImage = await convertBlobToBase64(imageData.blob)
           if (base64EncodedImage !== null) {
             srcUrl = base64EncodedImage.toString()
           }
@@ -295,7 +295,7 @@ const updateNoteLinks = async (
   return [contentWithValidImgSrc, attachmentUrls]
 }
 
-const revokeAttachmentsUrls = (attachments: string[]) => {
+function revokeAttachmentsUrls(attachments: string[]) {
   attachments.forEach((attachment) => {
     window.URL.revokeObjectURL(attachment)
   })
@@ -360,7 +360,8 @@ export const exportNoteAsPdfFile = async (
     }
     const pdfBlob = await convertHtmlStringToPdfBlob(htmlString, printOpts)
     const pdfName = `${filenamifyNoteTitle(note.title)}.pdf`
-    downloadBlob(pdfBlob, pdfName, () => revokeAttachmentsUrls(attachmentUrls))
+    downloadBlob(pdfBlob, pdfName)
+    revokeAttachmentsUrls(attachmentUrls)
   } catch (error) {
     console.warn(error)
     pushMessage({


### PR DESCRIPTION
Add attachment rendering in PDF and HTML
- Add attachment getter in PDF export (exports.ts)
- Add parsing note md content to replace `<img src='id'>` with valid note image id
  - id blob is replaced with object url link in PDF export
  - id blob is replaced with base64 encoding of the image
- Update downloadBlob to have cleanup callback (for revoking objectURLs in PDF export)

How it works:
Users can export the PDF and HTML and any image link attached to document which renders well in markdown preview should be exported inside downloaded PDF and HTML (see more details in commit description).

How it looks:
**- md:** 
  - [ImageGlobalSearchPDFExport.txt](https://github.com/BoostIO/BoostNote.next/files/5681100/ImageGlobalSearchPDFExport.txt)
  - [ImagesOnlyGlobalSearchPDFExport.txt](https://github.com/BoostIO/BoostNote.next/files/5681101/ImagesOnlyGlobalSearchPDFExport.txt)  

**- result: PDF & HTML**
   - [PDFExportDarkTheme.pdf](https://github.com/BoostIO/BoostNote.next/files/5681103/ImagesOnlyGlobalSearchPDFExportDarkTheme.pdf)
   - [PDFExportWhiteTheme.pdf](https://github.com/BoostIO/BoostNote.next/files/5681121/ImagesOnlyGlobalSearchPDFExportWhiteTheme.pdf)
   - [HTMLExport.txt](https://github.com/BoostIO/BoostNote.next/files/5681112/HTMLExport.txt)



**Test:**
- In electron Linux App (dev)
  - Test exporting PDF & HTML in local file system storage
- In electron Linux App production version (appImage)
  - Test exporting PDF & HTML from local file system storage
  - Test exporting PDF & HTML from cloud storage 

Test invalid attachements exporting, error message, see below:
![NoSuchImagePushMessage](https://user-images.githubusercontent.com/18196945/101944711-6ef88200-3bed-11eb-8723-36fe87b1764f.png)

**Error Handling:**
If attachment cannot be found, it is skipped and error message is shown to the user. The exporting continues with all valid attachments.



