### PR TITLE
Show Plain Text in Preview for Unrecognized Languages (#698)

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -114,6 +114,8 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
           })
         } else if (!ignoreMissing) {
           throw new Error(`Unknown language: \`${lang}\` is not registered`)
+        } else {
+          return;
         }
       }
 

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -98,25 +98,27 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
       const cmResult = [] as Node[]
       if (lang != null) {
         const mime = getMime(lang)
-        if (mime != null) {
-          CodeMirror.runMode(rawContent, mime, (text, style) => {
-            cmResult.push(
-              h(
-                'span',
-                {
-                  className: style
-                    ? 'cm-' + style.replace(/ +/g, ' cm-')
-                    : undefined,
-                },
-                text
-              )
-            )
-          })
-        } else if (!ignoreMissing) {
+        if (mime == null) {
+          if (ignoreMissing){
+            return
+          }
+
           throw new Error(`Unknown language: \`${lang}\` is not registered`)
-        } else {
-          return;
         }
+
+        CodeMirror.runMode(rawContent, mime, (text, style) => {
+          cmResult.push(
+            h(
+              'span',
+              {
+                className: style
+                  ? 'cm-' + style.replace(/ +/g, ' cm-')
+                  : undefined,
+              },
+              text
+            )
+          )
+        })
       }
 
       node.children = cmResult


### PR DESCRIPTION
Fixed #698.

Currently, we display invisible text when the language specified for the code block is not recognized.
This is because in `MarkdownPreviewer.tsx: rehypeCodeMirrorAttacher()`, there is an edge case where if language is not null but there is no mime found for this language that can be found in `CodeMirror.findModeByName`, we set `node.children` to `[]`. 

Fix this case by returning early before the `node.children = cmResult` assignment.

Tested with following languages after applying the change above:
java -> rendered with java highlighting
123f (made up language) -> rendered as plain text
(empty) -> rendered as plain text
