### PR TITLE
Fix HTML Tags Not Being Rendered (#737)

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -203,7 +203,7 @@ const MarkdownPreviewer = ({
             if (src != null && !src.match('/')) {
               const attachment = attachmentMap[src]
               if (attachment != null) {
-                return <AttachmentImage attachment={attachment} />
+                return <AttachmentImage attachment={attachment} {...props}/>
               }
             }
 

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -187,7 +187,7 @@ const MarkdownPreviewer = ({
       .use(remarkParse)
       .use(slug)
       .use(remarkEmoji, { emoticon: false })
-      .use([remarkRehype, { allowDangerousHTML: true }])
+      .use(remarkRehype, { allowDangerousHtml: true })
       .use(rehypeRaw)
       .use(rehypeSanitize, schema)
       .use(remarkMath)


### PR DESCRIPTION
Fixes #696

Boost Note currently seems to ignore all HTML tags (#737).

This PR allows `remarkRehype` to parse HTML tags as intended in #561, reflecting the changes in syntax-tree/mdast-util-to-hast#38. 

In addition, this PR will also allow attributes passed in `<img>` tags to be passed into the `AttachmentImage` component, allowing users to resize their images using this tag (#696).