### PR TITLE
Fix bug for saving document with shortcut (ctrl+s)

### DIFF
--- a/src/components/organisms/NotePageToolbar.tsx
+++ b/src/components/organisms/NotePageToolbar.tsx
@@ -49,6 +49,7 @@ import {
 } from '../../lib/electronOnly'
 import NotePageToolbarFolderHeader from '../molecules/NotePageToolbarFolderHeader'
 import path from 'path'
+import parsePath from 'path-parse'
 import { filenamify } from '../../lib/string'
 
 const Container = styled.div`
@@ -58,7 +59,7 @@ const Container = styled.div`
   flex-shrink: 0;
   -webkit-app-region: drag;
   padding: 0 8px;
-  ${borderBottom}
+  ${borderBottom};
   align-items: center;
   & > .left {
     flex: 1;
@@ -334,7 +335,7 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
         if (result.canceled || result.filePath == null) {
           return
         }
-        const parsedFilePath = path.parse(result.filePath)
+        const parsedFilePath = parsePath(result.filePath)
         switch (parsedFilePath.ext) {
           case '.html':
             const htmlString = await convertNoteDocToHtmlString(


### PR DESCRIPTION
**Add parsePath import** (fix for: #742)
- Fix a bug where path.parse is not available in current node version
- Add parsePath instead of path.parse 

The save command now does not throw error on save, but better solution could be to use path.parse from newer node. Can we update it?

Todo:
- [ ] After operation is finished, it would be nice to show user a push message/notification of the successfuly/failed export

Test
- In electron Linux App (dev)
- In electron Linux App production version (appImage)