### PR TITLE
Fix attachment urls being revoked too early

### DIFF
--- a/src/components/organisms/NotePageToolbar.tsx
+++ b/src/components/organisms/NotePageToolbar.tsx
@@ -30,7 +30,6 @@ import {
   convertNoteDocToHtmlString,
   convertNoteDocToMarkdownString,
   convertNoteDocToPdfBuffer,
-  revokeAttachmentsUrls,
 } from '../../lib/exports'
 import { usePreferences } from '../../lib/preferences'
 import { usePreviewStyle } from '../../lib/preview'
@@ -350,18 +349,15 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
             return
           case '.pdf':
             try {
-              const attachmentUrls: string[] = []
               const pdfBuffer = await convertNoteDocToPdfBuffer(
                 note,
                 preferences,
                 pushMessage,
                 getAttachmentData,
-                attachmentUrls,
                 previewStyle
               )
 
               await writeFile(result.filePath, pdfBuffer)
-              revokeAttachmentsUrls(attachmentUrls)
             } catch (error) {
               console.error(error)
               pushMessage({

--- a/src/lib/exports.ts
+++ b/src/lib/exports.ts
@@ -248,7 +248,7 @@ async function updateNoteLinks(
     ),
   ]
 
-  let contentWithValidImgSrc = content
+  let contentWithValidImageSource = content
   const attachmentErrors: string[] = []
   const attachmentUrls: string[] = []
   for (const attachment of attachmentMatches) {
@@ -292,7 +292,7 @@ async function updateNoteLinks(
       }
 
       if (srcUrl) {
-        contentWithValidImgSrc = contentWithValidImgSrc.replace(
+        contentWithValidImageSource = contentWithValidImageSource.replace(
           new RegExp(imageData.name, 'g'),
           srcUrl
         )
@@ -310,11 +310,11 @@ async function updateNoteLinks(
       )}],\nPlease check is such exists to properly export the PDF with attachments.`,
     })
   }
-  return [contentWithValidImgSrc, attachmentUrls]
+  return [contentWithValidImageSource, attachmentUrls]
 }
 
-function revokeAttachmentsUrls(attachmentsUrls: string[]) {
-  attachmentsUrls.forEach((attachmentUrl) => {
+function revokeAttachmentsUrls(attachmentUrls: string[]) {
+  attachmentUrls.forEach((attachmentUrl) => {
     window.URL.revokeObjectURL(attachmentUrl)
   })
 }
@@ -348,7 +348,7 @@ export async function convertNoteDocToPdfBuffer(
     .process(note.content)
 
   const markdownContent = output.toString('utf-8').trim() + '\n'
-  const [mdContentWithValidLinks, attachmentUrls] = await updateNoteLinks(
+  const [markdownContentWithValidLinks, attachmentUrls] = await updateNoteLinks(
     markdownContent,
     pushMessage,
     getAttachmentData
@@ -356,7 +356,7 @@ export async function convertNoteDocToPdfBuffer(
 
   try {
     const htmlString = generatePrintToPdfHTML(
-      mdContentWithValidLinks,
+      markdownContentWithValidLinks,
       preferences,
       previewStyle
     )


### PR DESCRIPTION
**Fix attachment urls being revoked too early** (#745 )

Fix ```parse.path``` to be able to test new PDF export
Update attachment logic to filter out duplicates
Fix attachment URLs being revoked too early

Test
- In electron Linux App (dev)
- In electron Linux App production version (appImage)