### PR TITLE
Fix bug for renaming folders in file system database

### DIFF
--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -29,7 +29,7 @@ import {
   isSubPathname,
   keys,
 } from './utils'
-import { generateId, getHexatrigesimalString } from '../string'
+import { escapeRegExp, generateId, getHexatrigesimalString } from '../string'
 import {
   prepareDirectory,
   readFileAsString,
@@ -258,7 +258,9 @@ class FSNoteDb implements NoteDb {
     await unlinkFile(attachmentPathname)
   }
 
-  async createNote(noteProps: Partial<NoteDocEditibleProps | NoteDocImportableProps>) {
+  async createNote(
+    noteProps: Partial<NoteDocEditibleProps | NoteDocImportableProps>
+  ) {
     const now = getNow()
     const noteDoc: NoteDoc = {
       _id: generateNoteId(),
@@ -493,7 +495,10 @@ class FSNoteDb implements NoteDb {
     const allFoldersToRename = this.getAllFolderUnderPathname(pathname).sort()
 
     const replacePathname = (folderPathname: string) => {
-      return folderPathname.replace(new RegExp(`^${pathname}`), newPathname)
+      return folderPathname.replace(
+        new RegExp(`^${escapeRegExp(pathname)}`, 'g'),
+        newPathname
+      )
     }
     await Promise.all(
       allFoldersToRename.map(async (folderPathname) => {
@@ -564,7 +569,7 @@ class FSNoteDb implements NoteDb {
 
   getAllFolderUnderPathname(pathname: string) {
     const allFolderPathnames = keys(this.data!.folderMap)
-    const pathnameRegexp = new RegExp(`^${pathname}/`)
+    const pathnameRegexp = new RegExp(`^${escapeRegExp(pathname)}/`, 'g')
     const subFolderPathnames = allFolderPathnames.filter((pathname) => {
       return pathnameRegexp.test(pathname)
     })

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -13,7 +13,7 @@ export function generateId(): string {
 export const generateRandomHex = () => randomBytes(32).toString('hex')
 
 export function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return value.replace(/[.*+?^${}()|\[\]\\]/g, '\\$&')
 }
 
 export function filenamify(value: string) {


### PR DESCRIPTION
**Fix bug for renaming folders in file system database** (#747)
- Add escape for "[" character in regex escape characters
- Update FSNoteDb to use the regex escapes while renaming folder

Todo:
- [ ] After operation is finished/failed, it would be nice to show user a push message/notification of the successfuly/failed rename/removal

Test
- In electron Linux App (dev)
- In electron Linux App production version (appImage)