### PR TITLE
Fix copy snippet without language

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -37,12 +37,6 @@ interface Element extends Parent {
   properties: { [key: string]: any }
 }
 
-function getMime(name: string) {
-  const modeInfo = CodeMirror.findModeByName(name)
-  if (modeInfo == null) return null
-  return modeInfo.mime || modeInfo.mimes![0]
-}
-
 interface RehypeCodeMirrorOptions {
   ignoreMissing: boolean
   plainText: string[]
@@ -97,14 +91,17 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
 
       const cmResult = [] as Node[]
       if (lang != null) {
-        const mime = getMime(lang)
-        if (mime == null) {
+        const modeInfo = CodeMirror.findModeByName(lang)
+        if (modeInfo == null) {
           if (ignoreMissing) {
             return
           }
 
           throw new Error(`Unknown language: \`${lang}\` is not registered`)
         }
+        const mime = modeInfo.mime || modeInfo.mimes![0]
+        parent.properties['data-ext'] = modeInfo.ext[0]
+        parent.properties['data-mime'] = mime
 
         CodeMirror.runMode(rawContent, mime, (text, style) => {
           cmResult.push(

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -87,19 +87,19 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
       }
       parent.properties.className = classNames
 
-      if (lang == null || lang === false || plainText.indexOf(lang) !== -1) {
-        return
-      }
-
       const rawContent = node.children[0].value as string
       // TODO: Stop using html attribute after exposing HAST Node is shipped
       parent.properties['data-raw'] = rawContent
+
+      if (lang == null || lang === false || plainText.indexOf(lang) !== -1) {
+        return
+      }
 
       const cmResult = [] as Node[]
       if (lang != null) {
         const mime = getMime(lang)
         if (mime == null) {
-          if (ignoreMissing){
+          if (ignoreMissing) {
             return
           }
 
@@ -203,7 +203,7 @@ const MarkdownPreviewer = ({
             if (src != null && !src.match('/')) {
               const attachment = attachmentMap[src]
               if (attachment != null) {
-                return <AttachmentImage attachment={attachment} {...props}/>
+                return <AttachmentImage attachment={attachment} {...props} />
               }
             }
 

--- a/src/components/atoms/markdown/CodeFence.tsx
+++ b/src/components/atoms/markdown/CodeFence.tsx
@@ -5,6 +5,7 @@ import Icon from '../Icon'
 import { mdiContentCopy, mdiContentSave } from '@mdi/js'
 import { flexCenter } from '../../../lib/styled/styleFunctions'
 import { downloadBlob } from '../../../lib/download'
+
 const CodeFenceContainer = styled.div`
   position: relative;
 `
@@ -36,39 +37,55 @@ const CodeFenceButton = styled.button`
     color: ${({ theme }) => theme.navButtonActiveColor};
   }
 `
-const CodeFence = (props: React.HTMLProps<HTMLPreElement> = {}) => {
+
+const CodeFence = (
+  props: React.HTMLProps<HTMLPreElement> & {
+    'data-raw'?: unknown
+    'data-ext'?: unknown
+    'data-mime'?: unknown
+  } = {}
+) => {
   if (props.className != null && props.className!.includes('CodeMirror')) {
-    const otherProps = { ...props }
-    const rawContent = props['data-raw']
-    delete otherProps['data-raw']
+    const {
+      'data-raw': dataRaw,
+      'data-ext': dataExt,
+      'data-mime': dataMime,
+      ...otherProps
+    } = props
     return (
       <CodeFenceContainer>
         <pre {...otherProps} />
-        <CodeFenceButton
-          onClick={() => {
-            copy(rawContent)
-          }}
-          title='Copy to Clipboard'
-        >
-          <Icon path={mdiContentCopy} />
-        </CodeFenceButton>
-        {rawContent && (
-          <CodeFenceButton
-            onClick={() => {
-              const blob = new Blob([rawContent], {
-                type: 'text/plain;charset=utf-8',
-              })
-              let ext = ''
-              if (props.className!.includes('language-')) {
-                ext = '.' + /language-(.+?)$/.exec(props.className!)![1]
-              }
-              downloadBlob(blob, 'snippet' + ext)
-            }}
-            title='Save to File'
-            style={{ right: '30px' }}
-          >
-            <Icon path={mdiContentSave} />
-          </CodeFenceButton>
+        {typeof dataRaw === 'string' && dataRaw.length > 0 && (
+          <>
+            <CodeFenceButton
+              onClick={() => {
+                copy(dataRaw)
+              }}
+              title='Copy to Clipboard'
+            >
+              <Icon path={mdiContentCopy} />
+            </CodeFenceButton>
+            <CodeFenceButton
+              onClick={() => {
+                let filename = 'snippet'
+                if (typeof dataExt === 'string' && dataExt.length > 0) {
+                  filename += `.${dataExt}`
+                }
+                const mime =
+                  typeof dataMime === 'string' && dataMime.length > 0
+                    ? dataMime
+                    : 'text/plain;charset=utf-8'
+                const blob = new Blob([dataRaw], {
+                  type: mime,
+                })
+                downloadBlob(blob, filename)
+              }}
+              title='Save to File'
+              style={{ right: '30px' }}
+            >
+              <Icon path={mdiContentSave} />
+            </CodeFenceButton>
+          </>
         )}
       </CodeFenceContainer>
     )

--- a/src/components/atoms/markdown/CodeFence.tsx
+++ b/src/components/atoms/markdown/CodeFence.tsx
@@ -4,7 +4,7 @@ import copy from 'copy-to-clipboard'
 import Icon from '../Icon'
 import { mdiContentCopy, mdiContentSave } from '@mdi/js'
 import { flexCenter } from '../../../lib/styled/styleFunctions'
-import { downloadBlob } from '../../../lib/download';
+import { downloadBlob } from '../../../lib/download'
 const CodeFenceContainer = styled.div`
   position: relative;
 `
@@ -20,7 +20,7 @@ const CodeFenceButton = styled.button`
   outline: none;
 
   background-color: rgba(0, 0, 0, 0.3);
-  ${flexCenter}
+  ${flexCenter};
 
   border: none;
   cursor: pointer;
@@ -52,19 +52,24 @@ const CodeFence = (props: React.HTMLProps<HTMLPreElement> = {}) => {
         >
           <Icon path={mdiContentCopy} />
         </CodeFenceButton>
-        {rawContent && <CodeFenceButton
-          onClick={() => {
-            var blob = new Blob([rawContent], { type: "text/plain;charset=utf-8" });
-            var ext = "";
-            if (props.className!.includes('language-'))
-              ext = "." + /language-(.+?)$/.exec(props.className!)![1]
-            downloadBlob(blob, "snippet" + ext);
-          }}
-          title='Save to File'
-          style={{ right: '30px' }}
-        >
-          <Icon path={mdiContentSave} />
-        </CodeFenceButton>}
+        {rawContent && (
+          <CodeFenceButton
+            onClick={() => {
+              const blob = new Blob([rawContent], {
+                type: 'text/plain;charset=utf-8',
+              })
+              let ext = ''
+              if (props.className!.includes('language-')) {
+                ext = '.' + /language-(.+?)$/.exec(props.className!)![1]
+              }
+              downloadBlob(blob, 'snippet' + ext)
+            }}
+            title='Save to File'
+            style={{ right: '30px' }}
+          >
+            <Icon path={mdiContentSave} />
+          </CodeFenceButton>
+        )}
       </CodeFenceContainer>
     )
   }


### PR DESCRIPTION
**Fix copy snippet without language** (#749)
- Reorder markdown preview attacher to set raw data even on null lang items
- Fix some style code issues and formatting in copy snipppet and save snippet as file

Test:
- In electron Linux App (dev)
- In electron Linux App production version (appImage)