### PR TITLE
Add clipboard status component

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -87,19 +87,19 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
       }
       parent.properties.className = classNames
 
-      if (lang == null || lang === false || plainText.indexOf(lang) !== -1) {
-        return
-      }
-
       const rawContent = node.children[0].value as string
       // TODO: Stop using html attribute after exposing HAST Node is shipped
       parent.properties['data-raw'] = rawContent
+
+      if (lang == null || lang === false || plainText.indexOf(lang) !== -1) {
+        return
+      }
 
       const cmResult = [] as Node[]
       if (lang != null) {
         const mime = getMime(lang)
         if (mime == null) {
-          if (ignoreMissing){
+          if (ignoreMissing) {
             return
           }
 
@@ -203,7 +203,7 @@ const MarkdownPreviewer = ({
             if (src != null && !src.match('/')) {
               const attachment = attachmentMap[src]
               if (attachment != null) {
-                return <AttachmentImage attachment={attachment} {...props}/>
+                return <AttachmentImage attachment={attachment} {...props} />
               }
             }
 

--- a/src/components/atoms/markdown/CodeFence.tsx
+++ b/src/components/atoms/markdown/CodeFence.tsx
@@ -4,7 +4,7 @@ import copy from 'copy-to-clipboard'
 import Icon from '../Icon'
 import { mdiContentCopy, mdiContentSave } from '@mdi/js'
 import { flexCenter } from '../../../lib/styled/styleFunctions'
-import { downloadBlob } from '../../../lib/download';
+import { downloadBlob } from '../../../lib/download'
 const CodeFenceContainer = styled.div`
   position: relative;
 `
@@ -20,7 +20,7 @@ const CodeFenceButton = styled.button`
   outline: none;
 
   background-color: rgba(0, 0, 0, 0.3);
-  ${flexCenter}
+  ${flexCenter};
 
   border: none;
   cursor: pointer;
@@ -52,19 +52,24 @@ const CodeFence = (props: React.HTMLProps<HTMLPreElement> = {}) => {
         >
           <Icon path={mdiContentCopy} />
         </CodeFenceButton>
-        {rawContent && <CodeFenceButton
-          onClick={() => {
-            var blob = new Blob([rawContent], { type: "text/plain;charset=utf-8" });
-            var ext = "";
-            if (props.className!.includes('language-'))
-              ext = "." + /language-(.+?)$/.exec(props.className!)![1]
-            downloadBlob(blob, "snippet" + ext);
-          }}
-          title='Save to File'
-          style={{ right: '30px' }}
-        >
-          <Icon path={mdiContentSave} />
-        </CodeFenceButton>}
+        {rawContent && (
+          <CodeFenceButton
+            onClick={() => {
+              const blob = new Blob([rawContent], {
+                type: 'text/plain;charset=utf-8',
+              })
+              let ext = ''
+              if (props.className!.includes('language-')) {
+                ext = '.' + /language-(.+?)$/.exec(props.className!)![1]
+              }
+              downloadBlob(blob, 'snippet' + ext)
+            }}
+            title='Save to File'
+            style={{ right: '30px' }}
+          >
+            <Icon path={mdiContentSave} />
+          </CodeFenceButton>
+        )}
       </CodeFenceContainer>
     )
   }

--- a/src/components/molecules/ClipboardStatus.tsx
+++ b/src/components/molecules/ClipboardStatus.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import styled from '../../lib/styled'
+
+const ClipboardItem = styled.div`
+  padding-left: 3px;
+  padding-right: 3px;
+  padding-top: 5px;
+  height: 24px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.uiTextColor};
+  user-select: none;
+
+  max-width: 300px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+
+  background-color: ${({ theme }) => theme.secondaryBackgroundColor};
+`
+
+const ClipboardStatus = () => {
+  const [clipboardItem, setClipboardItem] = useState('')
+  const { clipboard } = window.require('electron')
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      if (!clipboard.readImage().isEmpty()) {
+        setClipboardItem('Image Copied')
+      } else {
+        const clipboardTextRaw = clipboard.readText()
+        setClipboardItem(clipboardTextRaw)
+      }
+    }, 200)
+    return () => clearInterval(intervalId)
+  }, [clipboard])
+
+  return <ClipboardItem title={clipboardItem}>{clipboardItem}</ClipboardItem>
+}
+
+export default ClipboardStatus

--- a/src/components/organisms/NoteDetail.tsx
+++ b/src/components/organisms/NoteDetail.tsx
@@ -26,6 +26,7 @@ import EditorThemeSelect from '../molecules/EditorThemeSelect'
 import EditorKeyMapSelect from '../molecules/EditorKeyMapSelect'
 import { addIpcListener, removeIpcListener } from '../../lib/electronOnly'
 import { Position } from 'codemirror'
+import ClipboardStatus from '../molecules/ClipboardStatus'
 
 type NoteDetailProps = {
   note: NoteDoc
@@ -482,6 +483,7 @@ class NoteDetail extends React.Component<NoteDetailProps, NoteDetailState> {
             cursor={currentCursor}
             selections={currentSelections}
           />
+          <ClipboardStatus />
           <EditorKeyMapSelect />
           <EditorThemeSelect />
           <EditorIndentationStatus />


### PR DESCRIPTION
**Add clipboard status component**
- Add clipboard status component in the status bar
- Add clipboard status for text and image

This PR features also no language code snippet copy fix!

When user copies some text it goes into status bar. When user copies image, the message is displayed that image is in clipboard.

Examples:

Simple copy (works for code snippets, code blocks, any copied text outside or inside boostnote)
![ClipboardSimple](https://user-images.githubusercontent.com/18196945/103352992-f4ae7580-4aa7-11eb-9ad2-8d5a02be7331.png)

Image copied to clipboard
![ClipboardImage](https://user-images.githubusercontent.com/18196945/103352986-f37d4880-4aa7-11eb-9120-6faa925b291a.png)

Multiline clipboard selection copied, on hover, it shows whole content:
![MultilineClipboardHover](https://user-images.githubusercontent.com/18196945/103352996-f6783900-4aa7-11eb-8dbd-fba65e2b8424.png)

Test
- In electron Linux App (dev)
- In electron Linux App production version (appImage)