### PR TITLE
UI: Changed Switcher Style

### DIFF
--- a/src/components/atoms/ToolbarIconButton.tsx
+++ b/src/components/atoms/ToolbarIconButton.tsx
@@ -4,8 +4,8 @@ import Icon from './Icon'
 import { flexCenter } from '../../lib/styled/styleFunctions'
 
 const Container = styled.button`
-  height: 34px;
-  width: 34px;
+  height: 30px;
+  width: 30px;
   box-sizing: border-box;
   font-size: 18px;
   outline: none;
@@ -15,14 +15,15 @@ const Container = styled.button`
   ${flexCenter}
 
   border: none;
+  border-radius: 3px;
   cursor: pointer;
 
   transition: color 200ms ease-in-out;
   color: ${({ theme }) => theme.navItemColor};
   &:hover {
-    color: ${({ theme }) => theme.navButtonHoverColor};
+    background-color: ${({ theme }) => theme.navItemHoverBackgroundColor};
   }
-
+  &:hover,
   &:active,
   &.active {
     color: ${({ theme }) => theme.navButtonActiveColor};

--- a/src/components/organisms/NotePageToolbar.tsx
+++ b/src/components/organisms/NotePageToolbar.tsx
@@ -7,14 +7,14 @@ import React, {
 import styled from '../../lib/styled'
 import { NoteDoc, NoteStorage } from '../../lib/db/types'
 import {
-  mdiTextSubject,
-  mdiCodeTags,
   mdiViewSplitVertical,
   mdiTrashCan,
   mdiRestore,
   mdiStarOutline,
   mdiStar,
   mdiExportVariant,
+  mdiEye,
+  mdiPencil,
 } from '@mdi/js'
 import { borderBottom, flexCenter } from '../../lib/styled/styleFunctions'
 import ToolbarIconButton from '../atoms/ToolbarIconButton'
@@ -38,7 +38,6 @@ import { useDb } from '../../lib/db'
 import { useRouteParams } from '../../lib/routeParams'
 import { useAnalytics, analyticsEvents } from '../../lib/analytics'
 import { useToast } from '../../lib/toast'
-import TopbarSwitchSelector from '../atoms/TopbarSwitchSelector'
 import {
   openContextMenu,
   showSaveDialog,
@@ -489,7 +488,7 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
                   active={noteViewMode === 'edit'}
                   title={t('note.edit')}
                   onClick={selectEditMode}
-                  iconPath={mdiCodeTags}
+                  iconPath={mdiPencil}
                 />
                 <ToolbarIconButton
                   active={noteViewMode === 'split'}
@@ -501,7 +500,7 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
                   active={noteViewMode === 'preview'}
                   title={t('note.preview')}
                   onClick={selectPreviewMode}
-                  iconPath={mdiTextSubject}
+                  iconPath={mdiEye}
                 />
               </>
             ) : (
@@ -514,21 +513,17 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
                     onClick={toggleSplitEditMode}
                   />
                 )}
-                <TopbarSwitchSelector
-                  onClick={togglePreviewMode}
-                  items={[
-                    {
-                      active: noteViewMode !== 'preview',
-                      label: 'Edit',
-                      title: 'Select Edit Mode',
-                    },
-                    {
-                      active: noteViewMode === 'preview',
-                      label: 'Preview',
-                      title: 'Select Preview Mode',
-                    },
-                  ]}
-                />
+                {noteViewMode !== 'preview' ? (
+                  <ToolbarIconButton
+                    iconPath={mdiEye}
+                    onClick={selectPreviewMode}
+                  />
+                ) : (
+                  <ToolbarIconButton
+                    iconPath={mdiPencil}
+                    onClick={selectEditMode}
+                  />
+                )}
               </>
             )}
             <ToolbarSeparator />


### PR DESCRIPTION
## Description
I restyled the view mode switcher of the doc page to make it look the same as the team version.
(https://github.com/BoostIO/BoostNote.next/pull/758 needs to be merged before this to apply the correct text color.)

## Screenshot
| Before  | After |
| ------------- | ------------- |
| <img width="208" alt="Screen_Shot_2021-01-07_at_16 09 35" src="https://user-images.githubusercontent.com/2410692/103988350-4dc98800-51d1-11eb-888f-7f9e43bcc31f.png"> | <img width="197" alt="CleanShot 2021-01-08 at 16 42 26@2x" src="https://user-images.githubusercontent.com/2410692/103988371-5cb03a80-51d1-11eb-831e-c0bf05cbb8b8.png"> |
