### PR TITLE
Improve export consistency between HTML and PDF types

### DIFF
--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -33,6 +33,10 @@ export function excludeNoteIdPrefix(noteId: string): string {
   return noteId.replace(new RegExp(`^${NOTE_ID_PREFIX}`), '')
 }
 
+export function excludeFileProtocol(src: string) {
+  return src.replace('file://', '')
+}
+
 export function prependNoteIdPrefix(noteId: string): string {
   if (new RegExp(`^${NOTE_ID_PREFIX}`).test(noteId)) {
     return `${NOTE_ID_PREFIX}${noteId}`

--- a/src/lib/exports.ts
+++ b/src/lib/exports.ts
@@ -2,17 +2,16 @@ import unified from 'unified'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import remarkMath from 'remark-math'
-import rehypeDocument from 'rehype-document'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
 import rehypeKatex from 'rehype-katex'
+import remarkAdmonitions from 'remark-admonitions'
 import { mergeDeepRight } from 'ramda'
 import gh from 'hast-util-sanitize/lib/github.json'
 import { rehypeCodeMirror } from '../components/atoms/MarkdownPreviewer'
-import { downloadBlob, downloadString } from './download'
-import { AttachmentData, NoteDoc } from './db/types'
-import { Preferences } from './preferences'
+import { downloadBlob } from './download'
+import { Attachment, NoteDoc, ObjectMap } from './db/types'
 import { filenamify } from './string'
 import React from 'react'
 import remarkEmoji from 'remark-emoji'
@@ -20,9 +19,133 @@ import rehypeReact from 'rehype-react'
 import CodeFence from '../components/atoms/markdown/CodeFence'
 import { getGlobalCss, selectTheme } from './styled/styleUtil'
 import yaml from 'yaml'
-import { convertHtmlStringToPdfBuffer } from './electronOnly'
+import {
+  convertHtmlStringToPdfBuffer,
+  getPathByName,
+  mkdir,
+  readFile,
+  showOpenDialog,
+  writeFile,
+  readdir,
+} from './electronOnly'
+import { join } from 'path'
+import { dev } from '../electron/consts'
+import { excludeFileProtocol } from './db/utils'
 
-const getFrontMatter = (note: NoteDoc): string => {
+interface ImageData {
+  name: string
+  src?: string
+  blob?: Blob
+}
+
+interface CssStyleInfo {
+  filename: string
+  content: string | Buffer
+  cssLink?: string
+}
+
+const schema = mergeDeepRight(gh, {
+  attributes: {
+    '*': [...gh.attributes['*'], 'className', 'align'],
+    input: [...gh.attributes.input, 'checked'],
+    pre: ['dataRaw'],
+  },
+})
+
+export async function openDialog(): Promise<string> {
+  const result = await showOpenDialog({
+    properties: ['openDirectory', 'createDirectory'],
+    buttonLabel: 'Select Folder',
+    defaultPath: getPathByName('home'),
+  })
+  if (result.canceled) {
+    return ''
+  }
+  if (result.filePaths == null) {
+    return ''
+  }
+
+  return result.filePaths[0]
+}
+
+async function exportNoteAssets(
+  assetsFolderPathname: string,
+  cssStyles: CssStyleInfo[],
+  attachmentFilenames: string[],
+  attachmentMap: ObjectMap<Attachment>
+): Promise<string[]> {
+  const attachmentsFolderPathname = join(assetsFolderPathname, 'attachments')
+  if (attachmentFilenames.length > 0) {
+    await mkdir(assetsFolderPathname)
+    await mkdir(attachmentsFolderPathname)
+  }
+  if (cssStyles.length > 0 && attachmentFilenames.length == 0) {
+    await mkdir(assetsFolderPathname)
+  }
+
+  for (const cssStyle of cssStyles) {
+    await writeFile(
+      join(assetsFolderPathname, cssStyle.filename),
+      cssStyle.content
+    )
+  }
+
+  const exportedAttachmentKeys: string[] = []
+  for (const attachmentFileName of attachmentFilenames) {
+    try {
+      const attachment = attachmentMap[attachmentFileName]
+      if (!attachment) {
+        continue
+      }
+
+      const data = await attachment.getData()
+      if (!data) {
+        continue
+      }
+      if (data.type === 'src') {
+        const attachmentData = await readFile(excludeFileProtocol(data.src))
+        await writeFile(
+          join(attachmentsFolderPathname, attachmentFileName),
+          attachmentData
+        )
+      } else {
+        await writeFile(
+          join(attachmentsFolderPathname, attachmentFileName),
+          Buffer.from(await data.blob.arrayBuffer())
+        )
+      }
+
+      exportedAttachmentKeys.push(attachmentFileName)
+    } catch (err) {
+      console.warn('No attachment found for name: ' + attachmentFileName)
+      console.warn(err)
+    }
+  }
+  return exportedAttachmentKeys
+}
+
+async function writeKatexFonts(assetsFolder: string) {
+  const cssLinkRoot = getCssLinkCommonPath(false)
+  const katexFontsPath = dev
+    ? `${cssLinkRoot}/katex/dist/fonts`
+    : `${cssLinkRoot}/katex/fonts/`
+
+  try {
+    const fontsFilenames = await readdir(katexFontsPath)
+    if (fontsFilenames.length > 0) {
+      await mkdir(`${assetsFolder}/fonts/`)
+      for (const fontFilename of fontsFilenames) {
+        const fontContents = await readFile(`${katexFontsPath}/${fontFilename}`)
+        await writeFile(`${assetsFolder}/fonts/${fontFilename}`, fontContents)
+      }
+    }
+  } catch (error) {
+    console.warn(`Cannot find asset: ${katexFontsPath}`)
+    console.warn(error)
+  }
+}
+
+function getFrontMatter(note: NoteDoc): string {
   return [
     '---',
     yaml
@@ -36,71 +159,255 @@ const getFrontMatter = (note: NoteDoc): string => {
   ].join('\n')
 }
 
-const sanitizeSchema = mergeDeepRight(gh, {
-  attributes: { '*': ['className'] },
-})
-
-export async function convertNoteDocToHtmlString(
-  note: NoteDoc,
-  preferences: Preferences,
-  pushMessage: (context: any) => any,
-  getAttachmentData: (src: string) => Promise<undefined | AttachmentData>,
-  previewStyle?: string
-) {
-  const file = await unified()
-    .use(remarkParse)
-    .use(remarkMath)
-    .use(remarkRehype, { allowDangerousHtml: true })
-    .use(rehypeCodeMirror, {
-      ignoreMissing: true,
-      theme: preferences['markdown.codeBlockTheme'],
-    })
-    .use(rehypeRaw)
-    .use(rehypeSanitize, sanitizeSchema)
-    .use(rehypeDocument, {
-      title: note.title,
-      style: previewStyle,
-      css: 'https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css',
-      meta: { keywords: note.tags.join() },
-    })
-    .use(rehypeStringify)
-    .use(rehypeKatex)
-    .process(note.content)
-
-  const [htmlString, attachmentUrls] = await updateNoteLinks(
-    file.toString(),
-    pushMessage,
-    getAttachmentData,
-    true
-  )
-  if (attachmentUrls.length != 0) {
-    console.info('HTML export tried to export blobs as object URLs')
-  }
-  return htmlString
+function cssStyleLinkGenerator(href: string) {
+  return `<link rel="stylesheet" href="${href}" type="text/css"/>`
 }
 
-export const exportNoteAsHtmlFile = async (
-  note: NoteDoc,
-  preferences: Preferences,
-  pushMessage: (context: any) => any,
-  getAttachmentData: (src: string) => Promise<undefined | AttachmentData>,
+function cssStyleTagGenerator(content: string) {
+  return `<style type="text/css">${content}</style>`
+}
+
+function getPrintStyleForExports() {
+  return `<style media="print">
+pre code {
+  white-space: pre-wrap;
+}
+</style>
+`
+}
+
+function getCssLinkCommonPath(prependFilePrefix = false) {
+  const pathPrefix = (prependFilePrefix ? 'file://' : '') + getPathByName('app')
+  return pathPrefix + (dev ? '/../node_modules' : '/compiled/app')
+}
+
+async function getExportStylesInfo(
+  codeBlockTheme: string,
+  generalThemeName: string,
   previewStyle?: string
-): Promise<void> => {
+) {
+  const cssStyles: CssStyleInfo[] = []
+  const cssLinkRoot = getCssLinkCommonPath(true)
+  const cssFileRoot = getCssLinkCommonPath(false)
+  const markdownCodeBlockTheme =
+    codeBlockTheme === 'solarized-dark' ? 'solarized' : codeBlockTheme
+  const appThemeCss = getGlobalCss(selectTheme(generalThemeName))
+
+  if (appThemeCss) {
+    cssStyles.push({ filename: 'globalTheme.css', content: appThemeCss })
+  }
+  if (previewStyle) {
+    cssStyles.push({ filename: 'previewStyle.css', content: previewStyle })
+  }
+
+  const remarkAdmonitionsPathSuffix = dev
+    ? `remark-admonitions/styles/classic.css`
+    : `remark-admonitions/classic.css`
   try {
-    const htmlString = await convertNoteDocToHtmlString(
-      note,
-      preferences,
-      pushMessage,
-      getAttachmentData,
-      previewStyle
+    const remarkAdmonitionsStyle = await readFile(
+      join(cssFileRoot, remarkAdmonitionsPathSuffix)
     )
-    downloadString(htmlString, `${filenamify(note.title)}.html`, 'text/html')
-  } catch (error) {
+    cssStyles.push({
+      filename: 'remarkAdmonitions.css',
+      content: remarkAdmonitionsStyle,
+      cssLink: join(cssLinkRoot, remarkAdmonitionsPathSuffix),
+    })
+  } catch (err) {
+    console.warn(
+      `Cannot find asset: ${join(cssFileRoot, remarkAdmonitionsPathSuffix)}`
+    )
+  }
+
+  if (markdownCodeBlockTheme) {
+    const markdownCodeBlockThemePathSuffix = `codemirror/theme/${markdownCodeBlockTheme}.css`
+    try {
+      const markdownCodeBlockStyle = await readFile(
+        join(cssFileRoot, markdownCodeBlockThemePathSuffix)
+      )
+      cssStyles.push({
+        filename: `${markdownCodeBlockTheme}.css`,
+        content: markdownCodeBlockStyle,
+        cssLink: join(cssLinkRoot, markdownCodeBlockThemePathSuffix),
+      })
+    } catch (err) {
+      console.warn(
+        `Cannot find asset: ${join(
+          cssFileRoot,
+          markdownCodeBlockThemePathSuffix
+        )}`
+      )
+    }
+  }
+
+  const katexPathSuffix = dev
+    ? 'katex/dist/katex.min.css'
+    : 'katex/katex.min.css'
+  try {
+    const katexStyle = await readFile(join(cssFileRoot, katexPathSuffix))
+    cssStyles.push({
+      filename: `katex.min.css`,
+      content: katexStyle,
+      cssLink: join(cssLinkRoot, katexPathSuffix),
+    })
+  } catch (err) {
+    console.warn(`Cannot find asset: ${join(cssFileRoot, katexPathSuffix)}`)
+  }
+
+  return cssStyles
+}
+
+function generateHtmlMetadataFromNote(noteDoc: NoteDoc) {
+  return `<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+<meta name="keywords" content="${noteDoc.tags.join(', ')}"/>
+<title>${noteDoc.title}</title>
+`
+}
+
+function generateCssForHtml(
+  cssStyles: CssStyleInfo[],
+  exportedNoteName: string
+) {
+  return `
+${cssStyles
+  .map((cssStyle) =>
+    cssStyleLinkGenerator(`./${exportedNoteName}_assets/${cssStyle.filename}`)
+  )
+  .join('\n')}
+
+<!-- Print Styles -->
+${getPrintStyleForExports()}
+`
+}
+
+async function generateCssForPrintToPdf(
+  codeBlockTheme: string,
+  generalThemeName: string,
+  previewStyle?: string
+) {
+  const cssStyleInfos: CssStyleInfo[] = await getExportStylesInfo(
+    codeBlockTheme,
+    generalThemeName,
+    previewStyle
+  )
+  const cssStyles = cssStyleInfos
+    .map((cssStyleInfo) => {
+      if (cssStyleInfo.cssLink) {
+        return cssStyleLinkGenerator(cssStyleInfo.cssLink)
+      } else {
+        const content = cssStyleInfo.content.toString('utf-8').trim() + '\n'
+        return cssStyleTagGenerator(content)
+      }
+    })
+    .join('\n')
+
+  return `
+    ${cssStyles}
+
+    <!-- Print Styles -->
+    ${getPrintStyleForExports()}
+  `
+}
+
+function wrapContentInThemeHtml(content: string, generalThemeName: string) {
+  return `
+<div class="${generalThemeName}">
+  ${content}
+</div>`
+}
+
+function combineHtmlElementsIntoHtmlDocumentString(
+  bodyContent: string,
+  css?: string,
+  htmlMeta?: string
+) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+${htmlMeta ? htmlMeta : ''}
+${css ? css : ''}
+</head>
+<body>
+  ${bodyContent}
+</body>
+</html>
+`
+}
+
+function extractAttachmentsFromString(
+  content: string,
+  regex = /src="([0-9a-zA-Z-]*-[0-9a-zA-Z]{8,14}\.png)"/g
+) {
+  const attachmentGroups = [...content.matchAll(regex)]
+
+  return [
+    ...new Set(
+      attachmentGroups
+        .filter((group) => group.length > 0)
+        .map((group) => group[1])
+    ),
+  ]
+}
+
+async function updateAttachmentLinksToObjectUrls(
+  content: string,
+  pushMessage: (context: any) => any,
+  attachmentMap: ObjectMap<Attachment>
+): Promise<[string, string[]]> {
+  const attachmentMatches = extractAttachmentsFromString(content)
+
+  let contentWithValidImageSource = content
+  const attachmentErrors: string[] = []
+  const attachmentUrls: string[] = []
+  for (const attachmentKey of attachmentMatches) {
+    const attachment = attachmentMap[attachmentKey]
+    if (!attachment) {
+      attachmentErrors.push(attachmentKey)
+      continue
+    }
+
+    const attachmentData = await attachment.getData()
+    if (!attachmentData) {
+      attachmentErrors.push(attachmentKey)
+      continue
+    }
+    const imageData: ImageData =
+      attachmentData.type === 'blob'
+        ? { name: attachmentKey, blob: attachmentData.blob }
+        : { name: attachmentKey, src: attachmentData.src }
+
+    const imageLinkPattern = `src="${imageData.name}"`
+
+    let srcUrl = ''
+    if (imageData.src) {
+      srcUrl = imageData.src
+    } else if (imageData.blob) {
+      srcUrl = window.URL.createObjectURL(imageData.blob)
+      attachmentUrls.push(srcUrl)
+    }
+    if (srcUrl) {
+      contentWithValidImageSource = contentWithValidImageSource.replace(
+        new RegExp(imageLinkPattern, 'g'),
+        `src="${srcUrl}"`
+      )
+    }
+  }
+
+  if (attachmentErrors.length > 0) {
     pushMessage({
-      title: 'Note processing failed',
-      description: 'Please check markdown syntax and try again later.',
+      title: 'PDF export cannot find attachment data for attachments.',
+      description: `Cannot find attachments: [${attachmentErrors.join(
+        ', '
+      )}],\nPlease check if attachments exists to properly export the PDF with attachments.`,
     })
   }
+  return [contentWithValidImageSource, attachmentUrls]
+}
+
+function revokeAttachmentsUrls(attachmentUrls: string[]) {
+  attachmentUrls.forEach((attachmentUrl) => {
+    window.URL.revokeObjectURL(attachmentUrl)
+  })
 }
 
 export function convertNoteDocToMarkdownString(
@@ -114,228 +421,27 @@ export function convertNoteDocToMarkdownString(
   return content
 }
 
-export const exportNoteAsMarkdownFile = async (
+async function convertNoteDocToMarkdownHtmlString(
   note: NoteDoc,
-  includeFrontMatter: boolean
-): Promise<void> => {
-  const content = convertNoteDocToMarkdownString(note, includeFrontMatter)
-  downloadString(content, `${filenamify(note.title)}.md`, 'text/markdown')
-  return
-}
-
-const schema = mergeDeepRight(gh, {
-  attributes: {
-    '*': [...gh.attributes['*'], 'className', 'align'],
-    input: [...gh.attributes.input, 'checked'],
-    pre: ['dataRaw'],
-  },
-})
-
-const fetchCorrectMdThemeName = (theme: string) => {
-  return theme === 'solarized-dark' ? 'solarized' : theme
-}
-
-const getCssLinks = (preferences: Preferences) => {
-  const cssHrefs: string[] = []
-  const app = window.require('electron').remote.app
-  const isProd = app.isPackaged
-  const pathPrefix = 'file://' + app.getAppPath()
-  const parentPathTheme =
-    pathPrefix + (isProd === true ? '/compiled/app' : '/../node_modules')
-  const editorTheme = fetchCorrectMdThemeName(preferences['editor.theme'])
-  const markdownCodeBlockTheme = fetchCorrectMdThemeName(
-    preferences['markdown.codeBlockTheme']
-  )
-
-  const editorThemePath = `${parentPathTheme}/codemirror/theme/${editorTheme}.css`
-  cssHrefs.push(editorThemePath)
-  if (editorTheme !== markdownCodeBlockTheme) {
-    if (markdownCodeBlockTheme) {
-      const markdownCodeBlockThemePath = `${parentPathTheme}/codemirror/theme/${markdownCodeBlockTheme}.css`
-      cssHrefs.push(markdownCodeBlockThemePath)
-    }
-  }
-  return cssHrefs
-}
-
-const cssStyleLinkGenerator = (href: string) =>
-  `<link rel="stylesheet" href="${href}" type="text/css"/>`
-
-const getPrintStyle = () => `
-  <style media="print">
-    pre code {
-      white-space: pre-wrap;
-    }
-  </style>
-`
-
-interface ImageData {
-  name: string
-  src?: string
-  blob?: Blob
-}
-
-const generatePrintToPdfHTML = (
-  markdownHTML: string,
-  preferences: Preferences,
-  previewStyle?: string
-) => {
-  const cssHrefs: string[] = getCssLinks(preferences)
-  const generalThemeName = preferences['general.theme']
-  const cssLinks = cssHrefs
-    .map((href) => cssStyleLinkGenerator(href))
-    .join('\n')
-  const appThemeCss = getGlobalCss(selectTheme(generalThemeName))
-  const previewStyleCssEl = previewStyle ? `<style>${previewStyle}</style>` : ''
-  const appThemeCssEl = appThemeCss ? `<style>${appThemeCss}</style>` : ''
-
-  return `<!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
-        <!-- Preview styles -->
-        ${appThemeCssEl}
-        ${previewStyleCssEl}
-
-        <!-- Link tag styles -->
-        ${cssStyleLinkGenerator(
-          'https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css'
-        )}
-        ${cssLinks}
-
-        <!-- Print Styles -->
-        ${getPrintStyle()}
-      </head>
-      <body>
-        <div class="${generalThemeName}">
-          ${markdownHTML}
-        </div>
-      </body>
-    </html>
-  `
-}
-
-async function convertBlobToBase64(blob: Blob) {
-  const reader = new FileReader()
-  reader.readAsDataURL(blob)
-  return new Promise<string | ArrayBuffer | null>((resolve) => {
-    reader.onloadend = () => {
-      resolve(reader.result)
-    }
-  })
-}
-
-async function updateNoteLinks(
-  content: string,
-  pushMessage: (context: any) => any,
-  getAttachmentData: (src: string) => Promise<undefined | AttachmentData>,
-  htmlExport = false
-): Promise<[string, string[]]> {
-  // How name is stored:
-  //  const fileName = `${dashify(name)}-${getHexatrigesimalString(time++)
-  // todo: [komediruzecki-11/12/2020] Is regex correct,
-  //   can we improve it, do we support other file types/attachments?
-  const attachmentGroups = [
-    ...content.matchAll(/src="([0-9a-zA-Z-]*-[0-9a-zA-Z]{8,14}\.png)"/g),
-  ]
-
-  const attachmentMatches = [
-    ...new Set(
-      attachmentGroups
-        .filter((group) => group.length > 0)
-        .map((group) => group[1])
-    ),
-  ]
-
-  let contentWithValidImageSource = content
-  const attachmentErrors: string[] = []
-  const attachmentUrls: string[] = []
-  for (const attachment of attachmentMatches) {
-    const imageData: ImageData | undefined = await getAttachmentData(attachment)
-      .then((value) => {
-        if (!value) {
-          return
-        }
-        switch (value.type) {
-          case 'blob':
-            return { name: attachment, blob: value.blob }
-          case 'src':
-            return { name: attachment, src: value.src }
-        }
-      })
-      .catch((error) => {
-        console.log(
-          `Error during loading attachment ${attachment}, reason: ${
-            error ? error.message : 'Unknown'
-          }`
-        )
-        return undefined
-      })
-
-    if (imageData) {
-      let srcUrl = ''
-      if (imageData.src) {
-        srcUrl = imageData.src
-      } else if (imageData.blob) {
-        if (htmlExport) {
-          // Set url as base64 encoded image
-          const base64EncodedImage = await convertBlobToBase64(imageData.blob)
-          if (base64EncodedImage !== null) {
-            srcUrl = base64EncodedImage.toString()
-          }
-        } else {
-          srcUrl = window.URL.createObjectURL(imageData.blob)
-          // save attachment url for revoking
-          attachmentUrls.push(srcUrl)
-        }
-      }
-
-      if (srcUrl) {
-        contentWithValidImageSource = contentWithValidImageSource.replace(
-          new RegExp(imageData.name, 'g'),
-          srcUrl
-        )
-      }
-    } else {
-      attachmentErrors.push(attachment)
-    }
+  codeBlockTheme: string
+): Promise<string> {
+  const remarkAdmonitionOptions = {
+    tag: ':::',
+    icons: 'emoji',
+    infima: false,
   }
 
-  if (attachmentErrors.length > 0) {
-    pushMessage({
-      title: `PDF export cannot find attachment data for attachments.`,
-      description: `Cannot find attachments: [${attachmentErrors.join(
-        ', '
-      )}],\nPlease check is such exists to properly export the PDF with attachments.`,
-    })
-  }
-  return [contentWithValidImageSource, attachmentUrls]
-}
-
-function revokeAttachmentsUrls(attachmentUrls: string[]) {
-  attachmentUrls.forEach((attachmentUrl) => {
-    window.URL.revokeObjectURL(attachmentUrl)
-  })
-}
-
-export async function convertNoteDocToPdfBuffer(
-  note: NoteDoc,
-  preferences: Preferences,
-  pushMessage: (context: any) => any,
-  getAttachmentData: (src: string) => Promise<undefined | AttachmentData>,
-  previewStyle?: string
-): Promise<Buffer> {
   const output = await unified()
     .use(remarkParse)
     .use(remarkEmoji, { emoticon: false })
+    .use(remarkAdmonitions, remarkAdmonitionOptions)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
     .use(rehypeSanitize, schema)
     .use(remarkMath)
     .use(rehypeCodeMirror, {
       ignoreMissing: true,
-      theme: preferences['markdown.codeBlockTheme'],
+      theme: codeBlockTheme,
     })
     .use(rehypeKatex, { output: 'htmlAndMathml' })
     .use(rehypeReact, {
@@ -347,27 +453,137 @@ export async function convertNoteDocToPdfBuffer(
     .use(rehypeStringify)
     .process(note.content)
 
-  const markdownContent = output.toString('utf-8').trim() + '\n'
-  const [markdownContentWithValidLinks, attachmentUrls] = await updateNoteLinks(
-    markdownContent,
+  return output.toString('utf-8').trim() + '\n'
+}
+
+export const exportNoteAsMarkdownFile = async (
+  saveFolderPathname: string,
+  saveFilename: string,
+  note: NoteDoc,
+  attachmentMap: ObjectMap<Attachment>,
+  includeFrontMatter: boolean
+): Promise<void> => {
+  const exportedNoteName = `${filenamify(saveFilename)}`
+  const exportedNoteFilename = `${exportedNoteName}.md`
+  const saveLocation = join(saveFolderPathname, exportedNoteFilename)
+  const content = convertNoteDocToMarkdownString(note, includeFrontMatter)
+  const attachmentFilenames = extractAttachmentsFromString(
+    note.content,
+    /\(([0-9a-zA-Z-]*-[0-9a-zA-Z]{8,14}\.png)\)/g
+  )
+  const assetsFolderPathname = join(
+    saveFolderPathname,
+    `${exportedNoteName}_assets`
+  )
+  await exportNoteAssets(
+    assetsFolderPathname,
+    [],
+    attachmentFilenames,
+    attachmentMap
+  )
+
+  await writeFile(saveLocation, content)
+  return
+}
+
+export const exportNoteAsHtmlFile = async (
+  saveFolderPathname: string,
+  saveFilename: string,
+  note: NoteDoc,
+  codeBlockTheme: string,
+  generalThemeName: string,
+  pushMessage: (context: any) => any,
+  attachmentMap: ObjectMap<Attachment>,
+  previewStyle?: string
+): Promise<void> => {
+  try {
+    const markdownHtmlContent = await convertNoteDocToMarkdownHtmlString(
+      note,
+      codeBlockTheme
+    )
+
+    const exportedNoteName = `${filenamify(saveFilename)}`
+    const exportedNoteFilename = `${exportedNoteName}.html`
+    const saveLocation = join(saveFolderPathname, exportedNoteFilename)
+
+    const cssStyles: CssStyleInfo[] = await getExportStylesInfo(
+      codeBlockTheme,
+      generalThemeName,
+      previewStyle
+    )
+    const attachmentFilenames = extractAttachmentsFromString(
+      markdownHtmlContent
+    )
+    const assetsFolderPathname = join(
+      saveFolderPathname,
+      `${exportedNoteName}_assets`
+    )
+
+    const savedAttachmentKeys = await exportNoteAssets(
+      assetsFolderPathname,
+      cssStyles,
+      attachmentFilenames,
+      attachmentMap
+    )
+
+    await writeKatexFonts(assetsFolderPathname)
+
+    let contentWithValidImageSources = markdownHtmlContent
+    for (const attachmentKey of savedAttachmentKeys) {
+      const imageLinkPattern = `src="${attachmentKey}"`
+      contentWithValidImageSources = contentWithValidImageSources.replace(
+        new RegExp(imageLinkPattern, 'g'),
+        `src="./${exportedNoteName}_assets/attachments/${attachmentKey}"`
+      )
+    }
+
+    const htmlString = combineHtmlElementsIntoHtmlDocumentString(
+      wrapContentInThemeHtml(contentWithValidImageSources, generalThemeName),
+      generateCssForHtml(cssStyles, exportedNoteName),
+      generateHtmlMetadataFromNote(note)
+    )
+    await writeFile(saveLocation, htmlString)
+  } catch (error) {
+    pushMessage({
+      title: 'Note processing failed',
+      description: 'Please check markdown syntax and try again later.',
+    })
+    console.warn(error)
+  }
+}
+
+export async function convertNoteDocToPdfBuffer(
+  note: NoteDoc,
+  codeBlockTheme: string,
+  generalThemeName: string,
+  pushMessage: (context: any) => any,
+  attachmentMap: ObjectMap<Attachment>,
+  previewStyle?: string
+): Promise<Buffer> {
+  const markdownHtmlContent = await convertNoteDocToMarkdownHtmlString(
+    note,
+    codeBlockTheme
+  )
+  const [
+    markdownContentWithValidLinks,
+    attachmentUrls,
+  ] = await updateAttachmentLinksToObjectUrls(
+    markdownHtmlContent,
     pushMessage,
-    getAttachmentData
+    attachmentMap
+  )
+
+  const htmlString = combineHtmlElementsIntoHtmlDocumentString(
+    wrapContentInThemeHtml(markdownContentWithValidLinks, generalThemeName),
+    await generateCssForPrintToPdf(
+      codeBlockTheme,
+      generalThemeName,
+      previewStyle
+    ),
+    generateHtmlMetadataFromNote(note)
   )
 
   try {
-    const htmlString = generatePrintToPdfHTML(
-      markdownContentWithValidLinks,
-      preferences,
-      previewStyle
-    )
-
-    // Enable if we want tags inside PDF export
-    // const tagsStr =
-    //   note.tags.length > 0 ? `, tags: [${note.tags.join(' ')}]` : ''
-    // const headerFooter: Record<string, string> = {
-    //   title: `${note.title}${tagsStr}`,
-    //   url: `file://${filenamify(note.title)}.pdf`,
-    // }
     const printOpts = {
       // Needed for codemirorr themes (backgrounds)
       printBackground: true,
@@ -375,7 +591,6 @@ export async function convertNoteDocToPdfBuffer(
       // No margins 1, default margins 0, 2 - minimum margins
       marginsType: 0, // This could be chosen by user.
       pageSize: 'A4', // This could be chosen by user.
-      // headerFooter: headerFooter,
     }
     return await convertHtmlStringToPdfBuffer(htmlString, printOpts)
   } finally {
@@ -385,17 +600,19 @@ export async function convertNoteDocToPdfBuffer(
 
 export const exportNoteAsPdfFile = async (
   note: NoteDoc,
-  preferences: Preferences,
+  codeBlockTheme: string,
+  generalThemeName: string,
   pushMessage: (context: any) => any,
-  getAttachmentData: (src: string) => Promise<undefined | AttachmentData>,
+  attachmentMap: ObjectMap<Attachment>,
   previewStyle?: string
 ): Promise<void> => {
   try {
     const pdfBuffer = await convertNoteDocToPdfBuffer(
       note,
-      preferences,
+      codeBlockTheme,
+      generalThemeName,
       pushMessage,
-      getAttachmentData,
+      attachmentMap,
       previewStyle
     )
     const pdfName = `${filenamify(note.title)}.pdf`

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -83,6 +83,10 @@ module.exports = (env, argv) => {
             to: 'app/katex/katex.min.css',
           },
           {
+            from: path.join(__dirname, 'node_modules/katex/dist/fonts/'),
+            to: 'app/katex/fonts/',
+          },
+          {
             from: path.join(
               __dirname,
               'node_modules/remark-admonitions/styles/classic.css'


### PR DESCRIPTION
**Improve export consistency between HTML and PDF types** (#754)
- Add remark-admonitions for html generation
- Update metadata for html generation
- Refactor HTML export to use custom HTML generated previously for PDF only
- Refactor export functions
- Replace preferences object with actual needed preferences
- Update conversion functions for saving note document with shortcut
- Export css attachments for HTML
- Export css stylesheets
- Link css stylesheets in HTML string for HTML export
- Refactor PDF links update in markdown (remove HTML handling)
- Refactor shortcut saving HTML and Markdown
   - Add saveFolder and saveName
- Update logic for production paths (use API and dev variable)
- Add katex fonts exporting and katex.min.css instead of jsdeliver link

**Error handling:**
- When writing note attachment or asset fails, it is skipped
- User is notified of missing assets in console (consider pushMessage?)

Preview:
The export structure as described in #754 
![ExportsWithKatexFonts](https://user-images.githubusercontent.com/18196945/104093172-1dddbb80-5289-11eb-8c64-59be2a0eba18.png)

HTML rendering of admonitions:
![HTML_RenderingAdmonitions](https://user-images.githubusercontent.com/18196945/104093180-2df59b00-5289-11eb-8613-377a34c7a06a.png)

**Exported HTML and then printed PDF in Firefox (emojis work):**
[MarkdownFunctionalityFirefoxRendering.pdf](https://github.com/BoostIO/BoostNote.next/files/5791194/MarkdownFunctionalityFirefoxRendering.pdf)
**HTML & Assets:**
[Markdown Functionality Test.zip](https://github.com/BoostIO/BoostNote.next/files/5791196/Markdown.Functionality.Test.zip)

Tests:
  - Tried exporting with shortcut `ctrl+s` with type Markdown, PDF and HTML
  - Tried exporting with export buttons with type Markdown, PDF, and HTML
    - HTML is exported with assets (CSS files, CSS fonts, and attachments if any)
    - Markdown is exported only with attachments (no need for CSS)
    - PDF is exported as one file (embedded with attachments, stylesheets are rendered)

- In electron Linux App (dev)
- In electron Linux App production version (appImage)