### PR TITLE
fix(markdown-code-block-lang-mode): Fix accessing element of mimes and ext when they are undefined.

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -99,8 +99,8 @@ function rehypeCodeMirrorAttacher(options: Partial<RehypeCodeMirrorOptions>) {
 
           throw new Error(`Unknown language: \`${lang}\` is not registered`)
         }
-        const mime = modeInfo.mime || modeInfo.mimes![0]
-        parent.properties['data-ext'] = modeInfo.ext[0]
+        const mime = modeInfo.mime || modeInfo.mimes?.[0]
+        parent.properties['data-ext'] = modeInfo.ext?.[0]
         parent.properties['data-mime'] = mime
 
         CodeMirror.runMode(rawContent, mime, (text, style) => {


### PR DESCRIPTION
…d ext when they are undefined.

When code block is set in `dockerfile` language mode, properties `mimes` and `ext` are undefined so I add optional chaining when accessing their element.

![screen-shot-mode-info-obj](https://user-images.githubusercontent.com/23638151/107223942-62f03b80-6a49-11eb-9a21-1fc0e98d8f62.png)
![cannot-read-property-0-of-undefined](https://user-images.githubusercontent.com/23638151/107223967-697eb300-6a49-11eb-9688-e3a4761107f0.png)
