### PR TITLE
UI: Adjusted Font Size of Document Title

### DIFF
--- a/src/cloud/components/atoms/EditableInput.tsx
+++ b/src/cloud/components/atoms/EditableInput.tsx
@@ -184,6 +184,7 @@ const StyledEditableInput = styled.div`
     background-color: transparent;
     color: ${({ theme }) => theme.baseTextColor};
     cursor: pointer;
+    font-size: ${({ theme }) => theme.fontSizes.small}px;
     text-decoration: none !important;
     flex: 1;
     min-width: 0;


### PR DESCRIPTION
I adjusted the font size and made it the same with other breadcrumbs.

| Before  | After |
| ------------- | ------------- |
| <img width="400" alt="Screen_Shot_2021-02-17_at_12 07 40" src="https://user-images.githubusercontent.com/2410692/108465360-32b86080-72c5-11eb-89a1-0c558834b5b9.png"> | ![CleanShot 2021-02-19 at 15 11 25](https://user-images.githubusercontent.com/2410692/108465389-406de600-72c5-11eb-85c8-a817173a39f8.png) |