### PR TITLE
UI: Adjusted Styles of Context Menu

### DIFF
--- a/src/components/organisms/NoteContextView.tsx
+++ b/src/components/organisms/NoteContextView.tsx
@@ -270,7 +270,11 @@ const Separator = styled.div`
 
 const ControlItem = styled.div`
   display: flex;
+  align-items: center;
   flex-shrink: 0;
+  height: 30px;
+  color: ${({ theme }) => theme.navItemColor};
+  font-size: 14px;
 `
 
 const ControlItemLabelIconContainer = styled.div`
@@ -328,8 +332,8 @@ const ButtonItem = styled.button`
   display: flex;
   align-items: center;
   flex-shrink: 0;
-
   color: ${({ theme }) => theme.navItemColor};
+  font-size: 14px;
   background-color: ${({ theme }) => theme.navItemBackgroundColor};
   &:hover {
     background-color: ${({ theme }) => theme.navItemHoverBackgroundColor};

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -33,7 +33,7 @@ export const darkTheme: BaseTheme = {
   primaryColor: primaryColor,
   primaryDarkerColor: primaryDarkerColor,
   dangerColor: dangerColor,
-  borderColor: '#505050',
+  borderColor: '#45474B',
   noteListIconColor: light30Color,
   noteListActiveIconColor: light70Color,
   noteDetailIconColor: light30Color,


### PR DESCRIPTION
I adjusted some styles of the doc context menu on the local app to make it look close enough with the cloud one.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-02-20 at 15 15 08](https://user-images.githubusercontent.com/2410692/108585938-b25e3200-738e-11eb-9678-53434c1dbb09.png) | ![CleanShot 2021-02-20 at 14 50 49@2x](https://user-images.githubusercontent.com/2410692/108585944-bb4f0380-738e-11eb-92c8-a16661305e2b.png) |