### PR TITLE
Add Tooltip component

### DIFF
--- a/src/components/atoms/BottomBarButton.tsx
+++ b/src/components/atoms/BottomBarButton.tsx
@@ -1,21 +1,26 @@
 import React, { MouseEventHandler, FC } from 'react'
 import styled from '../../lib/styled'
 import { flexCenter, borderLeft } from '../../lib/styled/styleFunctions'
+import Tooltip from './Tooltip'
 
 interface BottomBarButtonProps {
   className?: string
   onClick?: MouseEventHandler<HTMLButtonElement>
+  tooltipText?: string
 }
 
 const BottomBarButton: FC<BottomBarButtonProps> = ({
   className,
   onClick,
   children,
+  tooltipText,
 }) => {
   return (
-    <Container className={className} onClick={onClick}>
-      {children}
-    </Container>
+    <Tooltip space={10} text={tooltipText}>
+      <Container className={className} onClick={onClick}>
+        {children}
+      </Container>
+    </Tooltip>
   )
 }
 

--- a/src/components/atoms/GeneralPortal.tsx
+++ b/src/components/atoms/GeneralPortal.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+interface GeneralPortalProps {
+  portalKey?: string
+}
+
+class GeneralPortal extends React.PureComponent<GeneralPortalProps> {
+  private containerEl = document.createElement('div')
+  constructor(props: GeneralPortalProps) {
+    super(props)
+  }
+
+  componentDidMount() {
+    document.body.appendChild(this.containerEl)
+  }
+
+  componentWillUnmount() {
+    document.body.removeChild(this.containerEl)
+  }
+
+  render() {
+    return ReactDOM.createPortal(
+      this.props.children,
+      this.containerEl,
+      this.props.portalKey
+    )
+  }
+}
+
+export default GeneralPortal

--- a/src/components/atoms/NavigatorButton.tsx
+++ b/src/components/atoms/NavigatorButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from '../../lib/styled'
 import Icon from './Icon'
+import Tooltip from './Tooltip'
 
 const ButtonContainer = styled.button`
   width: 24px;
@@ -45,14 +46,15 @@ const NavigatorButton = ({
   spin,
 }: NavigatorButtonProps) => {
   return (
-    <ButtonContainer
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      title={title}
-      className={active ? 'active' : ''}
-    >
-      <Icon path={iconPath} spin={spin} />
-    </ButtonContainer>
+    <Tooltip space={10} text={title}>
+      <ButtonContainer
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        className={active ? 'active' : ''}
+      >
+        <Icon path={iconPath} spin={spin} />
+      </ButtonContainer>
+    </Tooltip>
   )
 }
 

--- a/src/components/atoms/ToolbarButton.tsx
+++ b/src/components/atoms/ToolbarButton.tsx
@@ -3,6 +3,7 @@ import styled from '../../lib/styled'
 import Icon from './Icon'
 import { flexCenter, textOverflow } from '../../lib/styled/styleFunctions'
 import cc from 'classcat'
+import Tooltip from './Tooltip'
 
 interface ToolbarButtonProps {
   iconPath?: string
@@ -22,16 +23,17 @@ const ToolbarButton = ({
   limitWidth,
 }: ToolbarButtonProps) => {
   return (
-    <Container
-      className={cc([active && 'active', limitWidth && 'limitWidth'])}
-      title={title == null ? label : title}
-      onClick={onClick}
-    >
-      {iconPath != null && <Icon className='icon' path={iconPath} />}
-      {label != null && label.length > 0 && (
-        <div className='label'>{label}</div>
-      )}
-    </Container>
+    <Tooltip text={title == null ? label : title}>
+      <Container
+        className={cc([active && 'active', limitWidth && 'limitWidth'])}
+        onClick={onClick}
+      >
+        {iconPath != null && <Icon className='icon' path={iconPath} />}
+        {label != null && label.length > 0 && (
+          <div className='label'>{label}</div>
+        )}
+      </Container>
+    </Tooltip>
   )
 }
 

--- a/src/components/atoms/ToolbarIconButton.tsx
+++ b/src/components/atoms/ToolbarIconButton.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from '../../lib/styled'
 import Icon from './Icon'
 import { flexCenter } from '../../lib/styled/styleFunctions'
+import Tooltip from './Tooltip'
 
 const Container = styled.button`
   height: 32px;
@@ -12,7 +13,7 @@ const Container = styled.button`
   padding: 0 5px;
 
   background-color: transparent;
-  ${flexCenter}
+  ${flexCenter};
 
   border: none;
   border-radius: 3px;
@@ -49,15 +50,16 @@ const ToolbarIconButton = React.forwardRef(
     }: ToolbarButtonProps,
     ref
   ) => (
-    <Container
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      className={active ? 'active' : ''}
-      ref={ref}
-      title={title}
-    >
-      <Icon size={18} path={iconPath} />
-    </Container>
+    <Tooltip space={10} text={title}>
+      <Container
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        className={active ? 'active' : ''}
+        ref={ref}
+      >
+        <Icon size={18} path={iconPath} />
+      </Container>
+    </Tooltip>
   )
 )
 

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -1,0 +1,189 @@
+import React from 'react'
+import GeneralPortal from './GeneralPortal'
+import styled from '../../lib/styled/styled'
+import { BaseTheme } from '../../lib/styled/BaseTheme'
+
+interface TooltipProps {
+  text?: string
+  width?: number
+  arrowWidth?: number
+  space?: number
+  tooltipDelayMs?: number
+}
+
+interface TooltipStyle {
+  width: number | string
+  left?: number | string
+  top?: number | string
+  bottom?: number | string
+}
+
+interface TooltipArrowStyle {
+  width: number | string
+  left?: number | string
+  top?: number | string
+  bottom?: number | string
+  transform?: string
+  display?: string
+}
+
+interface TooltipState {
+  visible: boolean
+  style?: TooltipStyle
+  arrowStyle?: TooltipArrowStyle
+}
+
+interface TooltipBodyProps {
+  theme: BaseTheme
+  arrowStyle: TooltipArrowStyle
+}
+
+const TooltipBody = styled.div<BaseTheme & TooltipBodyProps>`
+  position: fixed;
+  padding: 5px;
+  background: ${({ theme }) => theme.tooltipBackgroundColor};
+  color: white;
+  box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.3);
+  text-align: center;
+  font-size: 11px;
+  border-radius: 6px;
+  z-index: 6000;
+
+  &::after {
+    display: ${({ arrowStyle }: TooltipBodyProps) => arrowStyle.display};
+    content: '';
+    position: absolute;
+    bottom: ${({ arrowStyle }: TooltipBodyProps) => arrowStyle.bottom};
+    top: ${({ arrowStyle }: TooltipBodyProps) => arrowStyle.top};
+    left: ${({ arrowStyle }: TooltipBodyProps) => arrowStyle.left};
+    transform: ${({ arrowStyle }: TooltipBodyProps) => arrowStyle.transform};
+    margin-left: ${({ arrowStyle }: TooltipBodyProps) => -arrowStyle.width}px;
+    border-width: ${({ arrowStyle }: TooltipBodyProps) => arrowStyle.width}px;
+    border-style: solid;
+    border-color: transparent transparent
+      ${({ theme }) => theme.tooltipBackgroundColor} transparent;
+  }
+`
+
+const TooltipContainer = styled.span`
+  //border-bottom: 1px dashed grey;
+`
+
+const DEFAULT_TOOLTIP_DELAY_MS = 500
+
+class Tooltip extends React.Component<TooltipProps, TooltipState> {
+  private readonly width: number
+  private readonly arrowWidth: number
+  private readonly space: number
+  private readonly tooltipDelayMs: number
+  private showTooltipTimer: any | null
+  tooltipContainerRef = React.createRef<HTMLSpanElement>()
+  tooltipRef = React.createRef<HTMLSpanElement>()
+  constructor(props: TooltipProps) {
+    super(props)
+
+    this.state = {
+      visible: false,
+      arrowStyle: {
+        width: '5px',
+      },
+    }
+
+    this.arrowWidth = props.arrowWidth || 6
+    this.width = props.width || 120
+    this.space = props.space || 4
+    this.tooltipDelayMs = props.tooltipDelayMs || DEFAULT_TOOLTIP_DELAY_MS
+
+    this.showTooltip = this.showTooltip.bind(this)
+    this.hideTooltip = this.hideTooltip.bind(this)
+  }
+
+  showTooltip() {
+    if (!this.tooltipContainerRef.current) return
+    const style: TooltipStyle = {
+      width: `${this.width}px`,
+    }
+    const arrowStyle: TooltipArrowStyle = {
+      width: `${this.arrowWidth}`,
+    }
+    const dimensions = this.tooltipContainerRef.current.getBoundingClientRect()
+
+    style.left = dimensions.left + dimensions.width / 2 - this.width / 2
+    arrowStyle.left = '50%'
+
+    // this.space might better be of width size not height offset like now
+    const leftMargin = document.body.clientWidth - this.width - this.space
+    if (style.left > leftMargin) {
+      // we could decide to not show arrow when not in center
+      // or use below logic to position it at the center of element which tooltip is shown
+      // arrowStyle.display = 'none'
+      let newLeftPosition = Math.max(this.space, style.left)
+      newLeftPosition = Math.min(newLeftPosition, leftMargin)
+      arrowStyle.left = `${
+        Math.abs(dimensions.left - newLeftPosition) + dimensions.width / 2
+      }px`
+    } else {
+      arrowStyle.display = 'block'
+    }
+
+    style.left = Math.max(this.space, style.left)
+    style.left = Math.min(style.left, leftMargin)
+
+    const topOfThePagePercent = 0.9
+    if (dimensions.top < topOfThePagePercent * window.innerHeight) {
+      style.top = dimensions.top + dimensions.height + this.space
+      if (this.state.arrowStyle) {
+        arrowStyle.bottom = '100%'
+        arrowStyle.top = 'auto'
+      }
+    } else {
+      style.bottom = window.innerHeight - dimensions.top + this.space
+      if (this.state.arrowStyle) {
+        arrowStyle.top = '100%'
+        arrowStyle.bottom = 'auto'
+        arrowStyle.transform = 'rotate(180deg)'
+      }
+    }
+
+    this.setState({
+      visible: true,
+      style,
+      arrowStyle,
+    })
+  }
+
+  hideTooltip() {
+    clearTimeout(this.showTooltipTimer)
+    this.setState({ visible: false })
+  }
+
+  render() {
+    return (
+      <TooltipContainer
+        onMouseOver={() => {
+          this.showTooltipTimer = setTimeout(
+            this.showTooltip,
+            this.tooltipDelayMs
+          )
+        }}
+        onMouseOut={this.hideTooltip}
+        ref={this.tooltipContainerRef}
+      >
+        {this.props.children}
+
+        {this.state.visible && this.props.text && (
+          <GeneralPortal>
+            <TooltipBody
+              arrowStyle={this.state.arrowStyle}
+              style={this.state.style}
+            >
+              {this.props.text}
+            </TooltipBody>
+          </GeneralPortal>
+        )}
+      </TooltipContainer>
+    )
+  }
+}
+
+export default Tooltip

--- a/src/components/molecules/EditorIndentationStatus.tsx
+++ b/src/components/molecules/EditorIndentationStatus.tsx
@@ -4,11 +4,13 @@ import { openContextMenu } from '../../lib/electronOnly'
 import { MenuItemConstructorOptions } from 'electron'
 import { capitalize } from '../../lib/string'
 import BottomBarButton from '../atoms/BottomBarButton'
+import { useTranslation } from 'react-i18next'
 
 const EditorIndentationStatus = () => {
   const { preferences, setPreferences } = usePreferences()
   const currentIndentType = preferences['editor.indentType']
   const currentIndentSize = preferences['editor.indentSize']
+  const { t } = useTranslation()
 
   const openEditorIndentationContextMenu = useCallback(() => {
     openContextMenu({
@@ -60,7 +62,10 @@ const EditorIndentationStatus = () => {
   }, [currentIndentType, currentIndentSize, setPreferences])
 
   return (
-    <BottomBarButton onClick={openEditorIndentationContextMenu}>
+    <BottomBarButton
+      tooltipText={t('editor.editorIndentStatus')}
+      onClick={openEditorIndentationContextMenu}
+    >
       {capitalize(currentIndentType)}: {currentIndentSize}
     </BottomBarButton>
   )

--- a/src/components/molecules/EditorKeyMapSelect.tsx
+++ b/src/components/molecules/EditorKeyMapSelect.tsx
@@ -5,10 +5,12 @@ import { MenuItemConstructorOptions } from 'electron'
 import BottomBarButton from '../atoms/BottomBarButton'
 import Icon from '../atoms/Icon'
 import { mdiKeyboard } from '@mdi/js'
+import { useTranslation } from 'react-i18next'
 
 const EditorKeyMapSelect = () => {
   const { preferences, setPreferences } = usePreferences()
   const editorKeyMap = preferences['editor.keyMap']
+  const { t } = useTranslation()
 
   const openThemeContextMenu = useCallback(() => {
     openContextMenu({
@@ -32,7 +34,10 @@ const EditorKeyMapSelect = () => {
   }, [setPreferences, editorKeyMap])
 
   return (
-    <BottomBarButton onClick={openThemeContextMenu}>
+    <BottomBarButton
+      tooltipText={t('editor.keymapSelect')}
+      onClick={openThemeContextMenu}
+    >
       <Icon path={mdiKeyboard} />
     </BottomBarButton>
   )

--- a/src/components/molecules/EditorThemeSelect.tsx
+++ b/src/components/molecules/EditorThemeSelect.tsx
@@ -6,11 +6,13 @@ import BottomBarButton from '../atoms/BottomBarButton'
 import Icon from '../atoms/Icon'
 import { mdiPaletteOutline } from '@mdi/js'
 import { themes } from '../../lib/CodeMirror'
+import { useTranslation } from 'react-i18next'
 
 const EditorThemeSelect = () => {
   const { preferences, setPreferences } = usePreferences()
   const editorTheme = preferences['editor.theme']
   const codeBlockTheme = preferences['markdown.codeBlockTheme']
+  const { t } = useTranslation()
 
   const openThemeContextMenu = useCallback(() => {
     openContextMenu({
@@ -48,7 +50,10 @@ const EditorThemeSelect = () => {
   }, [editorTheme, codeBlockTheme, setPreferences])
 
   return (
-    <BottomBarButton onClick={openThemeContextMenu}>
+    <BottomBarButton
+      tooltipText={t('editor.editorThemeSelect')}
+      onClick={openThemeContextMenu}
+    >
       <Icon path={mdiPaletteOutline} />
     </BottomBarButton>
   )

--- a/src/components/molecules/FolderNavigatorItem.tsx
+++ b/src/components/molecules/FolderNavigatorItem.tsx
@@ -238,16 +238,17 @@ const FolderNavigatorItem = ({
       control={
         <>
           <NavigatorButton
-            title='New Note'
+            title={t('navigator.newNote')}
             onClick={createNoteInFolder}
             iconPath={mdiTextBoxPlusOutline}
           />
           <NavigatorButton
-            title='New Subfolder'
+            title={t('navigator.newSubFolder')}
             onClick={createSubFolder}
             iconPath={mdiFolderMultiplePlusOutline}
           />
           <NavigatorButton
+            title={t('navigator.moreItems')}
             onClick={openMoreContextMenu}
             iconPath={mdiDotsVertical}
           />

--- a/src/components/molecules/NotePageToolbarNoteHeader.tsx
+++ b/src/components/molecules/NotePageToolbarNoteHeader.tsx
@@ -32,6 +32,8 @@ import Icon from '../atoms/Icon'
 import cc from 'classcat'
 import FolderTreeListItem from '../atoms/FolderTreeListItem'
 import { addIpcListener, removeIpcListener } from '../../lib/electronOnly'
+import Tooltip from '../atoms/Tooltip'
+import { useTranslation } from 'react-i18next'
 
 interface NotePageToolbarNoteHeaderProps {
   storageId: string
@@ -54,6 +56,7 @@ const NotePageToolbarNoteHeader = ({
 }: NotePageToolbarNoteHeaderProps) => {
   const { push } = useRouter()
   const { updateNote } = useDb()
+  const { t } = useTranslation()
 
   const folderDataList = useMemo<FolderData[]>(() => {
     if (noteFolderPathname === '/') {
@@ -180,7 +183,7 @@ const NotePageToolbarNoteHeader = ({
         <>
           <ToolbarSlashSeparator />
           <ToolbarButton
-            title='All Parent Folders'
+            title={t('toolbar.parentFolders')}
             iconPath={mdiDotsHorizontal}
             active={showingParentFolderListPopup}
             onClick={showParentFolderListPopup}
@@ -215,9 +218,9 @@ const NotePageToolbarNoteHeader = ({
           <ToolbarSlashSeparator />
           <ToolbarButton
             iconPath={mdiFolderOutline}
-            title={`Navigate to ${
-              folderDataList[folderDataList.length - 1].pathname
-            }`}
+            title={t('toolbar.navigateToFolder', {
+              folder: folderDataList[folderDataList.length - 1].pathname,
+            })}
             label={folderDataList[folderDataList.length - 1].name}
             limitWidth={true}
             onClick={() => {
@@ -266,13 +269,15 @@ const NoteTitleButton = ({ title, onClick }: NoteTitleButtonProps) => {
   const titleIsEmpty = title == null || title.trim().length === 0
 
   return (
-    <NoteTitleButtonContainer title='Edit Title' onClick={onClick}>
-      <Icon className='icon' path={mdiCardTextOutline} />
-      <div className={cc(['label', titleIsEmpty && 'empty'])}>
-        {titleIsEmpty ? 'Untitled' : title}
-      </div>
-      <Icon className='hoverIcon' path={mdiPencilOutline} />
-    </NoteTitleButtonContainer>
+    <Tooltip text={'Edit Title'}>
+      <NoteTitleButtonContainer onClick={onClick}>
+        <Icon className='icon' path={mdiCardTextOutline} />
+        <div className={cc(['label', titleIsEmpty && 'empty'])}>
+          {titleIsEmpty ? 'Untitled' : title}
+        </div>
+        <Icon className='hoverIcon' path={mdiPencilOutline} />
+      </NoteTitleButtonContainer>
+    </Tooltip>
   )
 }
 

--- a/src/components/organisms/NotePageToolbar.tsx
+++ b/src/components/organisms/NotePageToolbar.tsx
@@ -373,11 +373,13 @@ const NotePageToolbar = ({ storage, note }: NotePageToolbarProps) => {
               )}
               {noteViewMode !== 'preview' ? (
                 <ToolbarIconButton
+                  title={t('editor.showMarkdownPreview')}
                   iconPath={mdiEye}
                   onClick={selectPreviewMode}
                 />
               ) : (
                 <ToolbarIconButton
+                  title={t('editor.showEditor')}
                   iconPath={mdiPencil}
                   onClick={selectEditMode}
                 />

--- a/src/locales/enUS.ts
+++ b/src/locales/enUS.ts
@@ -15,7 +15,10 @@ export default {
 
     // Navigator
     'navigator.noStorage': 'There are no spaces',
+    'navigator.newNote': 'New Note',
+    'navigator.newSubFolder': 'New Subfolder',
     'navigator.createStorage': 'Click here to create one.',
+    'navigator.moreItems': 'More options',
 
     // Newsletter
     'newsletter.subscribe': 'Subscribe',
@@ -130,6 +133,14 @@ export default {
     'billing.addStorage': 'Add Extra Storage',
 
     'editor.editor': 'Editor',
+    'editor.keymapSelect': 'Keymap selection',
+    'editor.editorIndentStatus': 'Indent options',
+    'editor.editorThemeSelect': 'Select editor theme',
+    'editor.showMarkdownPreview': 'Show markdown preview',
+    'editor.showEditor': 'Show editor',
+
+    'toolbar.parentFolders': 'All Parent Folders',
+    'toolbar.navigateToFolder': 'Navigate to #{{folder}}',
 
     // Preferences
     'preferences.general': 'Preferences',


### PR DESCRIPTION
**Add Tooltip component** (#552)

- Add tooltip component
- Add basic portal component for tooltip
- Add tooltip component in navigator buttons
- Add tooltip for button components
- Add translation for button tooltip texts
- Add tooltip delay
- Show tooltip arrow on edges at the correct location
- Fix tooltip arrow center position issue

Few examples of how it looks:
![TooltipWorkspaceNewNoteButton](https://user-images.githubusercontent.com/18196945/108909853-61b43680-7625-11eb-871a-231acd30d92d.png)
![TooltipOpenContextView](https://user-images.githubusercontent.com/18196945/108909859-64169080-7625-11eb-8c31-a7a2b1ef1237.png)
![TooltipPathTooltip](https://user-images.githubusercontent.com/18196945/108909881-6aa50800-7625-11eb-8803-16b8de2230ab.png)
![TooltipAddLabelSolarizedDark](https://user-images.githubusercontent.com/18196945/108909914-7395d980-7625-11eb-885b-e289a58e3078.png)
![TooltipEditTitleSolarizedDark](https://user-images.githubusercontent.com/18196945/108909968-84464f80-7625-11eb-9fb9-e0cb148f441e.png)
![TooltipIndentOptionsBottomBar](https://user-images.githubusercontent.com/18196945/108909988-88726d00-7625-11eb-8c6a-12b346734868.png)

I left the coloring and styling to whoever can make it work and used tooltip background color available in the theme.
In this (blackish) color arrow is sometimes not seen so clearly and on a dark background, it would also be a bit harder to spot. Meaning separate colors for each theme (black/white/sepia) could be used, an example of that would be something like this:

![TooltipNavigateToFolder](https://user-images.githubusercontent.com/18196945/108910202-d25b5300-7625-11eb-9939-1342ef054634.png)
![TooltipShowMdPreviewSepia](https://user-images.githubusercontent.com/18196945/108910219-d7200700-7625-11eb-86cc-22b352eae6bd.png)

The non-transparent color would also help I think.

**Tested in** 
- Local dev
- Production AppImage (Linux)
