### PR TITLE
UI: Hide Member Length for Guests

### DIFF
--- a/src/cloud/components/organisms/Sidebar/SidebarTeamPickerContext.tsx
+++ b/src/cloud/components/organisms/Sidebar/SidebarTeamPickerContext.tsx
@@ -84,7 +84,7 @@ const SidebarTeamPickerContext = ({
                         {plur('Member', team.permissions.length)}
                       </>
                     ) : (
-                      <>( Guest )</>
+                      '( Guest )'
                     )}
                   </TeamSubtitle>
                 </TeamLabel>

--- a/src/cloud/components/organisms/Sidebar/SidebarTeamPickerContext.tsx
+++ b/src/cloud/components/organisms/Sidebar/SidebarTeamPickerContext.tsx
@@ -76,11 +76,16 @@ const SidebarTeamPickerContext = ({
                 <TeamLabel>
                   <TeamName>{team.name}</TeamName>
                   <TeamSubtitle>
-                    - {team.permissions.length}{' '}
-                    {plur('Member', team.permissions.length)}
-                    {!team.permissions
+                    {team.permissions
                       .map((p) => p.userId)
-                      .includes(currentUser.id) && ` ( Guest )`}
+                      .includes(currentUser.id) ? (
+                      <>
+                        - {team.permissions.length}{' '}
+                        {plur('Member', team.permissions.length)}
+                      </>
+                    ) : (
+                      <>( Guest )</>
+                    )}
                   </TeamSubtitle>
                 </TeamLabel>
               </TeamContainer>


### PR DESCRIPTION
I made the member length hidden for guests.

| Before  | After |
| ------------- | ------------- |
| <img width="295" alt="Screen_Shot_2021-02-17_at_11 56 44" src="https://user-images.githubusercontent.com/2410692/110075307-f22d0c80-7dc5-11eb-8bed-5cbb0b8b0b8a.png"> | ![image](https://user-images.githubusercontent.com/2410692/110075429-230d4180-7dc6-11eb-925f-a3322ea4a1c6.png) |