### PR TITLE
UI: Added 'reduced-width' to Archived Page

### DIFF
--- a/src/cloud/components/organisms/ArchivedPageContent.tsx
+++ b/src/cloud/components/organisms/ArchivedPageContent.tsx
@@ -25,6 +25,7 @@ const ArchivedPage = () => {
   return (
     <AppLayout
       rightLayout={{
+        className: 'reduced-width',
         topbar: {
           left: <BreadCrumbs team={team} />,
         },


### PR DESCRIPTION
I added `reduced-width` class to the Archived page like other pages.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-05 at 16 39 51](https://user-images.githubusercontent.com/2410692/110083187-bac45d00-7dd1-11eb-827e-36f835606485.png) | ![CleanShot 2021-03-05 at 16 40 03](https://user-images.githubusercontent.com/2410692/110083210-c2840180-7dd1-11eb-8b3c-84e51d2e92c9.png) |