### PR TITLE
UI: Removed Text Decoration from Tags Auto Complete

### DIFF
--- a/src/cloud/components/molecules/DocTagsList/TagsAutoCompleteInput.tsx
+++ b/src/cloud/components/molecules/DocTagsList/TagsAutoCompleteInput.tsx
@@ -265,12 +265,12 @@ const Container = styled.div`
     text-overflow: ellipsis;
     white-space: nowrap;
     color: ${({ theme }) => theme.subtleTextColor};
+    text-decoration: none;
 
     &:hover,
     &:focus {
       background: ${({ theme }) => theme.transparentPrimaryBackgroundColor};
       color: ${({ theme }) => theme.primaryTextColor};
-      text-decoration: none;
     }
   }
 `


### PR DESCRIPTION
I removed a weird text-decoration from the tags auto-complete feature.

| Before  | After |
| ------------- | ------------- |
| <img width="208" alt="Screen_Shot_2021-03-05_at_2 22 46_PM" src="https://user-images.githubusercontent.com/2410692/110099241-6d9db680-7de4-11eb-89d6-dbc0fc96e5d8.png"> | ![CleanShot 2021-03-05 at 18 53 33](https://user-images.githubusercontent.com/2410692/110099291-7abaa580-7de4-11eb-8f75-5af8a307a8da.png) |