### PR TITLE
UI: Fix Alignment of the Timeline Page Header

### DIFF
--- a/src/cloud/components/molecules/PageHeader.tsx
+++ b/src/cloud/components/molecules/PageHeader.tsx
@@ -41,6 +41,7 @@ const StyledPageHeader = styled.header`
   justify-content: space-between;
 
   & .icon {
+    display: flex;
     margin-right: 10px;
   }
 


### PR DESCRIPTION
I added `display: flex;` to the `PageHeader` to fix the alignment.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-08 at 13 22 26](https://user-images.githubusercontent.com/2410692/110274262-bdad9080-8011-11eb-904d-7fbf7f5e56da.png) | ![CleanShot 2021-03-08 at 13 22 42](https://user-images.githubusercontent.com/2410692/110274282-c8682580-8011-11eb-8e97-04e21d1bf2af.png) |