### PR TITLE
UI: Adjusted Link Styles in Preferences Modal

### DIFF
--- a/src/cloud/components/atoms/Link/AccountLink.tsx
+++ b/src/cloud/components/atoms/Link/AccountLink.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react'
 import querystring from 'querystring'
-import Link from './Link'
-import styled from '../../../lib/styled'
+import EmphasizedLink from './EmphasizedLink'
 
 export type AccountLinkIntent = 'delete'
 
@@ -24,32 +23,19 @@ const AccountLink: FC<AccountLinkProps> = ({
   beforeNavigate,
 }) => {
   return (
-    <StyledLink>
-      <Link
-        href={getAccountHref(intent, query)}
-        beforeNavigate={beforeNavigate}
-        className={className}
-        style={style}
-        draggable={draggable}
-      >
-        {children}
-      </Link>
-    </StyledLink>
+    <EmphasizedLink
+      href={getAccountHref(intent, query)}
+      beforeNavigate={beforeNavigate}
+      className={className}
+      style={style}
+      draggable={draggable}
+    >
+      {children}
+    </EmphasizedLink>
   )
 }
 
 export default AccountLink
-
-const StyledLink = styled.span`
-  a {
-    color: ${({ theme }) => theme.primaryTextColor};
-
-    &:hover,
-    &:focus {
-      text-decoration: none;
-    }
-  }
-`
 
 export function getAccountHref(intent: AccountLinkIntent, query?: any) {
   const basePathname = `account`

--- a/src/cloud/components/atoms/Link/AccountLink.tsx
+++ b/src/cloud/components/atoms/Link/AccountLink.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import querystring from 'querystring'
 import Link from './Link'
+import styled from '../../../lib/styled'
 
 export type AccountLinkIntent = 'delete'
 
@@ -23,19 +24,32 @@ const AccountLink: FC<AccountLinkProps> = ({
   beforeNavigate,
 }) => {
   return (
-    <Link
-      href={getAccountHref(intent, query)}
-      beforeNavigate={beforeNavigate}
-      className={className}
-      style={style}
-      draggable={draggable}
-    >
-      {children}
-    </Link>
+    <StyledLink>
+      <Link
+        href={getAccountHref(intent, query)}
+        beforeNavigate={beforeNavigate}
+        className={className}
+        style={style}
+        draggable={draggable}
+      >
+        {children}
+      </Link>
+    </StyledLink>
   )
 }
 
 export default AccountLink
+
+const StyledLink = styled.span`
+  a {
+    color: ${({ theme }) => theme.primaryTextColor};
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+`
 
 export function getAccountHref(intent: AccountLinkIntent, query?: any) {
   const basePathname = `account`

--- a/src/cloud/components/atoms/Link/EmphasizedLink.tsx
+++ b/src/cloud/components/atoms/Link/EmphasizedLink.tsx
@@ -1,0 +1,15 @@
+import styled from '../../../lib/styled'
+import Link from './Link'
+
+const EmphasizedLink = styled(Link)`
+  a {
+    color: ${({ theme }) => theme.primaryTextColor};
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+`
+
+export default EmphasizedLink

--- a/src/cloud/components/atoms/Link/TeamLink.tsx
+++ b/src/cloud/components/atoms/Link/TeamLink.tsx
@@ -3,6 +3,7 @@ import Link from './Link'
 import querystring from 'querystring'
 import { SerializedTeam } from '../../../interfaces/db/team'
 import { useRouter } from '../../../lib/router'
+import styled from '../../../lib/styled'
 
 export type TeamLinkIntent =
   | 'index'
@@ -47,21 +48,34 @@ const TeamLink = ({
   tabIndex = 0,
 }: TeamLinkProps) => {
   return (
-    <Link
-      href={getTeamLinkHref(team, intent, query)}
-      className={className}
-      style={style}
-      beforeNavigate={beforeNavigate}
-      onFocus={onFocus}
-      tabIndex={tabIndex}
-      id={id}
-    >
-      {children}
-    </Link>
+    <StyledLink>
+      <Link
+        href={getTeamLinkHref(team, intent, query)}
+        className={className}
+        style={style}
+        beforeNavigate={beforeNavigate}
+        onFocus={onFocus}
+        tabIndex={tabIndex}
+        id={id}
+      >
+        {children}
+      </Link>
+    </StyledLink>
   )
 }
 
 export default TeamLink
+
+const StyledLink = styled.span`
+  a {
+    color: ${({ theme }) => theme.primaryTextColor};
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+`
 
 export function getTeamLinkHref(
   team: TeamIdProps,

--- a/src/cloud/components/atoms/Link/TeamLink.tsx
+++ b/src/cloud/components/atoms/Link/TeamLink.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback } from 'react'
-import Link from './Link'
 import querystring from 'querystring'
 import { SerializedTeam } from '../../../interfaces/db/team'
 import { useRouter } from '../../../lib/router'
-import styled from '../../../lib/styled'
+import EmphasizedLink from './EmphasizedLink'
 
 export type TeamLinkIntent =
   | 'index'
@@ -48,34 +47,21 @@ const TeamLink = ({
   tabIndex = 0,
 }: TeamLinkProps) => {
   return (
-    <StyledLink>
-      <Link
-        href={getTeamLinkHref(team, intent, query)}
-        className={className}
-        style={style}
-        beforeNavigate={beforeNavigate}
-        onFocus={onFocus}
-        tabIndex={tabIndex}
-        id={id}
-      >
-        {children}
-      </Link>
-    </StyledLink>
+    <EmphasizedLink
+      href={getTeamLinkHref(team, intent, query)}
+      className={className}
+      style={style}
+      beforeNavigate={beforeNavigate}
+      onFocus={onFocus}
+      tabIndex={tabIndex}
+      id={id}
+    >
+      {children}
+    </EmphasizedLink>
   )
 }
 
 export default TeamLink
-
-const StyledLink = styled.span`
-  a {
-    color: ${({ theme }) => theme.primaryTextColor};
-
-    &:hover,
-    &:focus {
-      text-decoration: none;
-    }
-  }
-`
 
 export function getTeamLinkHref(
   team: TeamIdProps,

--- a/src/cloud/components/organisms/settings/IntegrationsTab.tsx
+++ b/src/cloud/components/organisms/settings/IntegrationsTab.tsx
@@ -580,7 +580,7 @@ const IntegrationsTab = () => {
                 <p>
                   Boost Note for Teams will show you the external content such
                   as Github issues, Trello cards, Google Docs, and much more
-                  automatically. What do you want on Boost Note for Teams?{' '}
+                  automatically. What do you want on Boost Note for Teams?
                   <button
                     className='item-info-request'
                     onClick={() =>
@@ -653,7 +653,13 @@ const StyledServiceListItem = styled.li`
     small {
       color: ${({ theme }) => theme.subtleTextColor};
       a {
+        color: ${({ theme }) => theme.primaryTextColor};
         text-decoration: underline;
+
+        &:hover,
+        &:focus {
+          text-decoration: none;
+        }
       }
     }
   }

--- a/src/cloud/components/organisms/settings/TeamInfoTab.tsx
+++ b/src/cloud/components/organisms/settings/TeamInfoTab.tsx
@@ -38,13 +38,12 @@ const TeamInfoTab = () => {
 
           <SectionDescription>
             Once you delete this space we will remove all associated data. There
-            is no turning back.
+            is no turning back.{' '}
             <TeamLink
               intent='delete'
               team={team}
               beforeNavigate={() => closeSettingsTab()}
             >
-              {' '}
               {t('general.delete')}
             </TeamLink>
           </SectionDescription>

--- a/src/cloud/components/organisms/settings/UpgradeTab.tsx
+++ b/src/cloud/components/organisms/settings/UpgradeTab.tsx
@@ -23,6 +23,7 @@ import { stripePublishableKey } from '../../../lib/consts'
 import CustomLink from '../../atoms/Link/CustomLink'
 import PlanTables from '../Subscription/PlanTables'
 import { UpgradePlans } from '../../../lib/stripe'
+import styled from '../../../lib/styled'
 
 const stripePromise = loadStripe(stripePublishableKey)
 
@@ -100,7 +101,7 @@ const UpgradeTab = () => {
                   onProCallback={() => onUpgradeCallback('pro')}
                   onTrialCallback={() => setShowTrialPopup(true)}
                 />
-                <p>
+                <StyledFYI>
                   * For larger businesses or those in highly regulated
                   industries, please{' '}
                   <CustomLink
@@ -112,7 +113,7 @@ const UpgradeTab = () => {
                     contact our sales department
                   </CustomLink>
                   .
-                </p>
+                </StyledFYI>
               </StyledSmallFont>
             </Section>
           </Container>
@@ -164,5 +165,17 @@ const UpgradeTab = () => {
     </Column>
   )
 }
+
+const StyledFYI = styled.p`
+  .type-link {
+    text-decoration: underline;
+
+    &:hover,
+    &:focus {
+      color: ${({ theme }) => theme.primaryTextColor};
+      text-decoration: none;
+    }
+  }
+`
 
 export default UpgradeTab


### PR DESCRIPTION
I applied the`primaryTextColor` to the bottom links of the preferences modal to make it look more readable.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-08 at 13 32 28](https://user-images.githubusercontent.com/2410692/110276022-9fe22a80-8015-11eb-8d00-38dd865344c0.png) | ![CleanShot 2021-03-08 at 13 36 26](https://user-images.githubusercontent.com/2410692/110276042-ae304680-8015-11eb-8e3f-d045441e7cf1.png) |
| ![CleanShot 2021-03-08 at 13 41 54](https://user-images.githubusercontent.com/2410692/110276067-bc7e6280-8015-11eb-9c39-b8c3f2497fc5.png) | ![image](https://user-images.githubusercontent.com/2410692/110276171-ecc60100-8015-11eb-91da-58eafb3888e6.png) |
| ![CleanShot 2021-03-08 at 14 00 53](https://user-images.githubusercontent.com/2410692/110276705-129fd580-8017-11eb-9ba3-7e4e9b028c29.png) | ![CleanShot 2021-03-08 at 14 02 20](https://user-images.githubusercontent.com/2410692/110276718-1c293d80-8017-11eb-99ec-f855921df699.png) |


