### PR TITLE
UI: Fixed Alignment of the Archived Page Content

### DIFF
--- a/src/cloud/components/organisms/DocPage/View.tsx
+++ b/src/cloud/components/organisms/DocPage/View.tsx
@@ -137,7 +137,7 @@ const ViewPage = ({
 
 const StyledViewDocLayout = styled.div`
   ${rightSidePageLayout}
-  margin: auto;
+  margin: 0 auto;
 `
 
 const StyledContent = styled.div`


### PR DESCRIPTION
I adjusted the auto margin of the page content to fix the issue when it's archived.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/2410692/110281848-cce80a80-8020-11eb-84ee-572bc3ec08ec.png) | ![CleanShot 2021-03-08 at 15 02 06](https://user-images.githubusercontent.com/2410692/110281884-de311700-8020-11eb-8942-c406a5eaa49d.png) |