### PR TITLE
ignore corrupt (unable to read mime type) attachments

### DIFF
--- a/static/main-preload.js
+++ b/static/main-preload.js
@@ -97,8 +97,8 @@
   }
 
   async function readFileTypeFromBuffer(buffer) {
-    const { mime } = await FileType.fromBuffer(buffer)
-    return mime
+    const result = await FileType.fromBuffer(buffer)
+    return result != null ? result.mime : ''
   }
 
   function parseCSON(value) {


### PR DESCRIPTION
Correctly handle `undefined` on mime type extraction.

This will cause corrupt attachments to be ignored.