### PR TITLE
UI: Restyled Backlink

### DIFF
--- a/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/DocContextMenu/index.tsx
+++ b/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/DocContextMenu/index.tsx
@@ -9,11 +9,11 @@ import {
   mdiArrowRight,
   mdiChevronLeft,
   mdiChevronRight,
-  mdiFileDocumentOutline,
   mdiAccountGroupOutline,
   mdiClockOutline,
   mdiLabelMultipleOutline,
   mdiAccountMultiplePlusOutline,
+  mdiArrowBottomLeft,
 } from '@mdi/js'
 import { useToast } from '../../../../../../lib/stores/toast'
 import { zIndexModalsBackground } from '../styled'
@@ -472,7 +472,7 @@ const DocContextMenu = ({
                                 id={`context__backlink__${doc.id}`}
                               >
                                 <Icon
-                                  path={mdiFileDocumentOutline}
+                                  path={mdiArrowBottomLeft}
                                   size={18}
                                   className='context__icon'
                                 />
@@ -888,6 +888,7 @@ const Container = styled.div`
     display: flex;
     align-items: end;
     line-height: 18px;
+    text-decoration: none;
   }
 
   .context__list + .context__flexible__button {


### PR DESCRIPTION
I restyled the backlink.

- Replaced icon
- Removed underline

| Before  | After |
| ------------- | ------------- |
| ![Clipboard 2021-15-03 at 12 54 55 PM](https://user-images.githubusercontent.com/2410692/111738919-8074b880-88c5-11eb-9324-9890405c490c.png) | ![CleanShot 2021-03-19 at 15 09 07](https://user-images.githubusercontent.com/2410692/111738942-8b2f4d80-88c5-11eb-9816-74b725cecacc.png) |