### PR TITLE
UI: Restyled Embedded Doc Link

### DIFF
--- a/src/cloud/components/atoms/MarkdownView/styles.ts
+++ b/src/cloud/components/atoms/MarkdownView/styles.ts
@@ -24,7 +24,8 @@ export const defaultPreviewStyle = ({ theme }: StyledProps) => `
     flex: 0 0 auto;
     display: flex;
     flex-direction: column;
-    padding-top: ${theme.space.xsmall}px;
+    padding-top: ${theme.space.xxsmall}px;
+    padding-left: ${theme.space.xxsmall}px;
     cursor: pointer;
     overflow: hidden;
 
@@ -75,7 +76,7 @@ export const defaultPreviewStyle = ({ theme }: StyledProps) => `
     & > div {
       flex: 1;
       min-width: 0;
-      padding: ${theme.space.xsmall}px ${theme.space.small}px;
+      padding: ${theme.space.xsmall}px ${theme.space.small}px ${theme.space.xsmall}px ${theme.space.xxsmall}px;
     }
 
     h1, a {

--- a/src/cloud/components/atoms/MarkdownView/styles.ts
+++ b/src/cloud/components/atoms/MarkdownView/styles.ts
@@ -102,6 +102,7 @@ export const defaultPreviewStyle = ({ theme }: StyledProps) => `
       margin-right: 5px;
       width: 20px;
       height: 20px;
+      vertical-align: middle;
     }
   }
 


### PR DESCRIPTION
I adjusted the styles of the embedded doc link.

- Adjusted alignment of the icons
- Adjusted spacing

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-19 at 15 19 40](https://user-images.githubusercontent.com/2410692/111740359-f548f200-88c7-11eb-9cf7-495969bb2201.png) | ![CleanShot 2021-03-19 at 19 37 19](https://user-images.githubusercontent.com/2410692/111767894-98126800-88ea-11eb-9a17-f3d5c225498e.png) |