### PR TITLE
UI: Show Full Month Name (Revision)

### DIFF
--- a/src/cloud/lib/date.ts
+++ b/src/cloud/lib/date.ts
@@ -28,7 +28,7 @@ export function getFormattedBoosthubDate(date: string, prefixed = false) {
 export function getFormattedDateTime(
   date: string,
   prefix?: string,
-  timeFormat = 'HH:mm, dd MMM'
+  timeFormat = 'HH:mm, dd MMMM u'
 ) {
   const converted = new Date(date)
   const yesterday = new Date()


### PR DESCRIPTION
I changed the time format from `HH:mm, dd MMM` to `HH:mm, dd MMMM u` to show the full month name because there is plenty of space, and doesn't have to be shortened.

<img width="233" alt="Screen Shot 2021-03-16 at 4 21 11 PM" src="https://user-images.githubusercontent.com/2410692/111745161-95eee000-88cf-11eb-87ee-c9d8fb933e11.png">