### PR TITLE
UI: Adjusted Alignment of the "Labels"

### DIFF
--- a/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/DocContextMenu/index.tsx
+++ b/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/DocContextMenu/index.tsx
@@ -384,7 +384,7 @@ const DocContextMenu = ({
               {currentUserPermissions != null && (
                 <>
                   <div className='context__row'>
-                    <label className='context__label'>
+                    <label className='context__label' style={{ height: 37 }}>
                       <IconMdi
                         path={mdiLabelMultipleOutline}
                         size={18}


### PR DESCRIPTION
I added height to adjust the alignment of the section header "Labels".

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-19 at 16 34 43](https://user-images.githubusercontent.com/2410692/111747380-9b015e80-88d2-11eb-8ce2-ff699c032a2d.png) | ![CleanShot 2021-03-19 at 16 43 30](https://user-images.githubusercontent.com/2410692/111747412-a2286c80-88d2-11eb-948d-8b9eeb089ead.png) |