### PR TITLE
UI: Show Header with Link in Preview Mode

### DIFF
--- a/src/cloud/components/atoms/LinkableHeader.tsx
+++ b/src/cloud/components/atoms/LinkableHeader.tsx
@@ -20,7 +20,7 @@ const LinkableHeader = ({
 }: LinkableHeaderProps) => {
   return (
     <StyledLinkableHeader as={as} id={id} {...rest}>
-      <StyledHeaderLink href={`#${id}`}>
+      <StyledHeaderLink href={`#${id}`} className='link-icon'>
         <IconMdi path={mdiLinkVariant} />
       </StyledHeaderLink>
       {children}
@@ -33,11 +33,11 @@ export default LinkableHeader
 const StyledLinkableHeader = styled.h1`
   position: relative;
 
-  a {
+  .link-icon {
     display: none;
   }
 
-  &:hover a {
+  &:hover .link-icon {
     display: block;
   }
 `
@@ -54,6 +54,6 @@ const StyledHeaderLink = styled.a`
   text-align: center;
 
   > svg {
-    margin-top: -4px;
+    margin-top: 4px;
   }
 `


### PR DESCRIPTION
Currently, when the header has a link, it won't appear when it's in preview mode. (In split view mode is fine.)

- `LinkableHeader` was causing this issue, so I fixed it.
- While doing that, I also adjusted the alignment of the link icon.

## Split View
![CleanShot 2021-03-19 at 16 59 17](https://user-images.githubusercontent.com/2410692/111750382-858e3380-88d6-11eb-8752-b02d49b98edf.png)

## Preview
| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-19 at 17 04 04](https://user-images.githubusercontent.com/2410692/111750453-98a10380-88d6-11eb-806f-6f35e8a0ba44.png) | ![image](https://user-images.githubusercontent.com/2410692/111750652-d30aa080-88d6-11eb-9783-66005d91de74.png) |