### PR TITLE
UI: Added Guest Count and Description

### DIFF
--- a/src/cloud/components/organisms/settings/MembersTab.tsx
+++ b/src/cloud/components/organisms/settings/MembersTab.tsx
@@ -47,6 +47,7 @@ import { SerializedGuest } from '../../../interfaces/db/guest'
 import EmojiIcon from '../../atoms/EmojiIcon'
 import { getDocTitle } from '../../../lib/utils/patterns'
 import SettingsTeamForm from '../../molecules/SettingsTeamForm'
+import { guestsPerMember } from '../../../lib/subscription'
 
 const MembersTab = () => {
   const { t } = useTranslation()
@@ -625,6 +626,18 @@ const MembersTab = () => {
                       <Spinner className='relative' style={{ top: 2 }} />
                     )}
                   </Flexbox>
+                  <SectionDescription>
+                    Guests are people external to your team who you want to work
+                    with on specific documents. They can be invited to
+                    individual documents but not an entire workspace.
+                  </SectionDescription>
+                  <p>
+                    {permissions.length > 0
+                      ? `${
+                          permissions.length * guestsPerMember - guestsMap.size
+                        } remaining ${plur('seat', permissions.length)}. `
+                      : 'No Remaining seats. '}
+                  </p>
                   <StyledMembersTable>
                     <thead className='table-header'>
                       <th>User</th>
@@ -708,6 +721,7 @@ const TopMargin = styled.div`
 
 const StyledMembersTable = styled.table`
   width: 100%;
+  margin-top: ${({ theme }) => theme.space.default}px;
 
   .table-header {
     text-align: left;
@@ -765,7 +779,6 @@ const StyledMembersTable = styled.table`
 const StyledGuestInactiveText = styled.p`
   margin-top: ${({ theme }) => theme.space.medium}px;
   margin-bottom: ${({ theme }) => theme.space.default}px;
-  line-height: 1.6;
 `
 
 export default MembersTab

--- a/src/cloud/components/organisms/settings/styled.ts
+++ b/src/cloud/components/organisms/settings/styled.ts
@@ -370,6 +370,7 @@ export const SectionDescription = styled.small`
   color: ${({ theme }) => theme.subtleTextColor};
   display: block;
   margin-bottom: ${({ theme }) => theme.space.xsmall}px;
+  line-height: 1.6;
 `
 
 export const SectionFlexLeft = styled.div`


### PR DESCRIPTION
I added the guest count and description to the Guest menu (after upgraded) on the Members tab.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-03-19 at 17 27 08](https://user-images.githubusercontent.com/2410692/111766803-4b7a5d00-88e9-11eb-90e6-2b8938c6f2ac.png) | ![CleanShot 2021-03-19 at 19 24 04](https://user-images.githubusercontent.com/2410692/111766843-546b2e80-88e9-11eb-8c5a-7c0558d5234d.png) |