### PR TITLE
Add initial drag n drop implementation (Wiki mode, local space)

### DIFF
--- a/src/components/atoms/NavigatorHeader.tsx
+++ b/src/components/atoms/NavigatorHeader.tsx
@@ -3,6 +3,7 @@ import styled from '../../lib/styled'
 import { textOverflow } from '../../lib/styled/styleFunctions'
 import Icon from './Icon'
 import { mdiChevronRight, mdiChevronDown } from '@mdi/js'
+import cc from 'classcat'
 
 const HeaderContainer = styled.header`
   position: relative;
@@ -73,28 +74,50 @@ const ClickableContainer = styled.div`
   &.subtle {
     color: ${({ theme }) => theme.disabledUiTextColor};
   }
+
+  &.dragged-over {
+    .dragged-over {
+      border-color: ${({ theme }) => theme.secondaryBorderColor};
+    }
+    background-color: ${({ theme }) =>
+      theme.secondaryButtonBackgroundColor} !important;
+  }
 `
 
 interface NavigatorHeaderProps {
   label: string
   active?: boolean
+  draggedOver?: boolean
   control?: React.ReactNode
   onContextMenu?: React.MouseEventHandler<HTMLDivElement>
   folded?: boolean
   onClick?: React.MouseEventHandler<HTMLDivElement>
+  onDrop?: (event: React.DragEvent) => void
+  onDragOver?: (event: React.DragEvent) => void
+  onDragLeave?: (event: React.DragEvent) => void
 }
 
 const NavigatorHeader = ({
   folded,
   label,
   active = false,
+  draggedOver,
   onContextMenu,
   onClick,
+  onDrop,
+  onDragOver,
+  onDragLeave,
   control,
 }: NavigatorHeaderProps) => {
   return (
     <HeaderContainer onContextMenu={onContextMenu}>
-      <ClickableContainer onClick={onClick} className={active ? 'active' : ''}>
+      <ClickableContainer
+        onClick={onClick}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        className={cc([active && 'active', draggedOver && 'dragged-over'])}
+      >
         {folded != null && (
           <Icon path={folded ? mdiChevronRight : mdiChevronDown} size={18} />
         )}

--- a/src/components/atoms/NavigatorItem.tsx
+++ b/src/components/atoms/NavigatorItem.tsx
@@ -32,6 +32,15 @@ const Container = styled.div`
       opacity: 1;
     }
   }
+
+  &.dragged-over {
+    border-radius: 3px;
+    .dragged-over {
+      border-color: ${({ theme }) => theme.secondaryBorderColor};
+    }
+    background-color: ${({ theme }) =>
+      theme.secondaryButtonBackgroundColor} !important;
+  }
 `
 
 const FoldButton = styled.button`
@@ -90,7 +99,7 @@ const ClickableContainer = styled.button`
 `
 
 const Label = styled.div`
-  ${textOverflow}
+  ${textOverflow};
   flex: 1;
   font-size: 14px;
 
@@ -128,12 +137,16 @@ interface NavigatorItemProps {
   active?: boolean
   subtle?: boolean
   alert?: boolean
+  draggable?: boolean
+  draggedOver?: boolean
   onFoldButtonClick?: (event: React.MouseEvent) => void
   onClick?: (event: React.MouseEvent) => void
   onContextMenu?: (event: React.MouseEvent) => void
+  onDragStart?: (event: React.DragEvent) => void
   onDrop?: (event: React.DragEvent) => void
   onDragOver?: (event: React.DragEvent) => void
   onDragEnd?: (event: React.DragEvent) => void
+  onDragLeave?: (event: React.DragEvent) => void
   onDoubleClick?: (event: React.MouseEvent) => void
 }
 
@@ -148,15 +161,19 @@ const NavigatorItem = ({
   // TODO: Delete dot placeholder style
   dotPlaceholder,
   active,
+  draggable,
   subtle,
   alert,
   onFoldButtonClick,
   onClick,
   onDoubleClick,
   onContextMenu,
+  onDragStart,
   onDrop,
   onDragOver,
   onDragEnd,
+  onDragLeave,
+  draggedOver,
 }: NavigatorItemProps) => {
   return (
     <Container
@@ -164,11 +181,15 @@ const NavigatorItem = ({
         className,
         active && 'active',
         visibleControl && 'visibleControl',
+        draggedOver && 'dragged-over',
       ])}
       onContextMenu={onContextMenu}
+      onDragStart={onDragStart}
       onDrop={onDrop}
       onDragOver={onDragOver}
       onDragEnd={onDragEnd}
+      onDragLeave={onDragLeave}
+      draggable={draggable}
     >
       {!dotPlaceholder && folded != null && (
         <FoldButton

--- a/src/components/molecules/FolderNoteNavigatorFragment.tsx
+++ b/src/components/molecules/FolderNoteNavigatorFragment.tsx
@@ -4,6 +4,7 @@ import {
   NoteDoc,
   PopulatedFolderDoc,
   ObjectMap,
+  NoteDocEditibleProps,
 } from '../../lib/db/types'
 import { useRouteParams, StorageNotesRouteParams } from '../../lib/routeParams'
 import { useGeneralStatus } from '../../lib/generalStatus'
@@ -25,6 +26,16 @@ interface FolderNoteNavigatorFragment {
     noteId: string
   ) => Promise<NoteDoc | undefined>
   trashNote: (storageId: string, noteId: string) => Promise<NoteDoc | undefined>
+  updateNote(
+    storageId: string,
+    noteId: string,
+    noteProps: Partial<NoteDocEditibleProps>
+  ): Promise<NoteDoc | undefined>
+  renameFolder: (
+    storageName: string,
+    pathname: string,
+    newName: string
+  ) => Promise<void>
 }
 
 const FolderNoteNavigatorFragment = ({
@@ -35,6 +46,8 @@ const FolderNoteNavigatorFragment = ({
   bookmarkNote,
   unbookmarkNote,
   trashNote,
+  updateNote,
+  renameFolder,
 }: FolderNoteNavigatorFragment) => {
   const { folderMap, id: storageId } = storage
 
@@ -145,6 +158,8 @@ const FolderNoteNavigatorFragment = ({
             bookmarkNote={bookmarkNote}
             unbookmarkNote={unbookmarkNote}
             trashNote={trashNote}
+            renameFolder={renameFolder}
+            updateNote={updateNote}
           />
         )
       })}

--- a/src/components/molecules/NoteNavigatorItem.tsx
+++ b/src/components/molecules/NoteNavigatorItem.tsx
@@ -1,10 +1,19 @@
-import React, { useCallback, MouseEventHandler } from 'react'
+import React, { useCallback, MouseEventHandler, useState } from 'react'
 import NavigatorItem from '../atoms/NavigatorItem'
 import { mdiCardTextOutline, mdiDotsVertical } from '@mdi/js'
 import { useStorageRouter } from '../../lib/storageRouter'
-import { NoteDoc } from '../../lib/db/types'
+import { NoteDoc, NoteDocEditibleProps } from '../../lib/db/types'
 import NavigatorButton from '../atoms/NavigatorButton'
 import { openContextMenu } from '../../lib/electronOnly'
+import { useToast } from '../../lib/toast'
+import { useRouter } from '../../lib/router'
+import { useGeneralStatus } from '../../lib/generalStatus'
+import {
+  folderPathnameFormat,
+  getTransferableTextData,
+  noteIdFormat,
+  setTransferableTextData,
+} from '../../lib/dnd'
 
 interface NoteNavigatorItemProps {
   storageId: string
@@ -23,6 +32,16 @@ interface NoteNavigatorItemProps {
     noteId: string
   ) => Promise<NoteDoc | undefined>
   trashNote: (storageId: string, noteId: string) => Promise<NoteDoc | undefined>
+  updateNote(
+    storageId: string,
+    noteId: string,
+    noteProps: Partial<NoteDocEditibleProps>
+  ): Promise<NoteDoc | undefined>
+  renameFolder: (
+    storageName: string,
+    pathname: string,
+    newName: string
+  ) => Promise<void>
 }
 
 const NoteNavigatorItem = ({
@@ -36,9 +55,15 @@ const NoteNavigatorItem = ({
   bookmarkNote,
   unbookmarkNote,
   trashNote,
+  updateNote,
+  renameFolder,
 }: NoteNavigatorItemProps) => {
+  const [draggedOver, setDraggedOver] = useState<boolean>(false)
   const emptyTitle = noteTitle.trim().length === 0
   const { navigateToNote } = useStorageRouter()
+  const { pushMessage } = useToast()
+  const { push } = useRouter()
+  const { openSideNavFolderItemRecursively } = useGeneralStatus()
 
   const navigate = useCallback(() => {
     navigateToNote(storageId, noteId, noteFolderPath)
@@ -75,6 +100,81 @@ const NoteNavigatorItem = ({
     [storageId, noteId, noteBookmarked, bookmarkNote, unbookmarkNote, trashNote]
   )
 
+  const handleDragOverNoteItem = useCallback((e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'move'
+    setDraggedOver(true)
+  }, [])
+
+  const handleDragStartNoteItem = (event: React.DragEvent) => {
+    setTransferableTextData(event, noteIdFormat, noteId)
+  }
+
+  const handleDropFolderToNoteItem = (
+    sourceFolderPathname: string,
+    destinationFolderPathname: string
+  ) => {
+    const sourceFolderName = sourceFolderPathname.substring(
+      sourceFolderPathname.lastIndexOf('/')
+    )
+    const newFolderPathname = `${destinationFolderPathname}${sourceFolderName}`
+    renameFolder(
+      storageId,
+      sourceFolderPathname == '' ? '/' : sourceFolderPathname,
+      newFolderPathname
+    )
+      .then(() => {
+        // refresh works for file system (FSNote) database
+        push(`/app/storages/${storageId}/notes${newFolderPathname}`)
+        openSideNavFolderItemRecursively(storageId, newFolderPathname)
+      })
+      .catch((err) => {
+        pushMessage({
+          title: 'Folder Structure Update Failed',
+          description: `Updating folder location failed. Reason: ${
+            err != null && err.message != null ? err.message : 'Unknown'
+          }`,
+        })
+      })
+  }
+
+  const handleDropNoteToNoteFolder = (
+    noteId: string,
+    destinationFolderPathname: string
+  ) => {
+    // move folder pathname of the note to new location (target destination)
+    updateNote(storageId, noteId, {
+      folderPathname: destinationFolderPathname,
+    }).then((r) => console.log('updated note', r))
+  }
+
+  const handleDropNavigatorItem = (event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDraggedOver(false)
+
+    const sourceFolderPathname = getTransferableTextData(
+      event,
+      folderPathnameFormat
+    )
+    if (sourceFolderPathname != null) {
+      handleDropFolderToNoteItem(sourceFolderPathname, noteFolderPath)
+    } else {
+      const noteId = getTransferableTextData(event, noteIdFormat)
+      if (noteId == null) {
+        return
+      }
+      handleDropNoteToNoteFolder(noteId, noteFolderPath)
+    }
+  }
+
+  const handleDragLeaveNoteItem = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDraggedOver(false)
+  }, [])
+
   return (
     <NavigatorItem
       active={active}
@@ -90,6 +190,12 @@ const NoteNavigatorItem = ({
           onClick={openNoteContextMenu}
         />
       }
+      draggable={true}
+      draggedOver={draggedOver}
+      onDragOver={(e) => handleDragOverNoteItem(e)}
+      onDragStart={handleDragStartNoteItem}
+      onDrop={handleDropNavigatorItem}
+      onDragLeave={(e) => handleDragLeaveNoteItem(e)}
     />
   )
 }

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -2,10 +2,37 @@ import { NoteDoc } from './db/types'
 import { convertFileListToArray } from './dom'
 
 const noteFormat = 'application/x-boost-note-json'
+export const noteIdFormat = 'text/note-id'
+export const folderPathnameFormat = 'text/folder-path'
 
 export interface TransferrableNoteData {
   storageId: string
   note: NoteDoc
+}
+
+export function getTransferableTextData(
+  event: React.DragEvent | DragEvent,
+  format: string
+): string | null {
+  if (event.dataTransfer == null) return null
+
+  const data = event.dataTransfer.getData(format)
+  if (data.length === 0) {
+    return null
+  }
+
+  return data
+}
+
+export function setTransferableTextData(
+  event: React.DragEvent | DragEvent,
+  format: string,
+  data: string
+) {
+  if (event.dataTransfer == null) {
+    return
+  }
+  event.dataTransfer.setData(format, data)
 }
 
 export function getTransferrableNoteData(


### PR DESCRIPTION
**Add initial drag n drop implementation** (#860, #575, #690, #571)

Add folder drag and drop
Add note drag and drop
Add note and folder to workspace drag and drop
Add a note to a note drag and drop
Add rename folder error handling (same folder pathname exists)
Add drag leave for folder/workspace/note leave event (dragged over effect)

Demo:
https://user-images.githubusercontent.com/18196945/113562045-c344c900-9605-11eb-9049-c06940a33de3.mp4

Open Points:
- [ ] Styling of dragged-over

**Tested in** 
- Local dev
- Production AppImage (Linux)
