### PR TITLE
Add basic keymap handling

### DIFF
--- a/src/cloud/components/atoms/EditableInput.tsx
+++ b/src/cloud/components/atoms/EditableInput.tsx
@@ -151,7 +151,7 @@ const EditableInput = ({
 }
 
 const StyledInput = styled.input`
-  ${inputStyle}
+  ${inputStyle};
   flex: 1 2 30px;
   width: 30px;
 `

--- a/src/components/PreferencesModal/KeymapTab.tsx
+++ b/src/components/PreferencesModal/KeymapTab.tsx
@@ -17,11 +17,7 @@ const KeymapTab = () => {
 
   const keymap = useMemo(() => {
     const keymap = preferences['general.keymap']
-    if (keymap != null) {
-      return [...keymap.entries()]
-    } else {
-      return []
-    }
+    return [...keymap.entries()]
   }, [preferences])
 
   const getKeymapItemSectionKey = useCallback((keymapItem: KeymapItem) => {

--- a/src/components/PreferencesModal/KeymapTab.tsx
+++ b/src/components/PreferencesModal/KeymapTab.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 import { Section, SectionHeader } from './styled'
 import { usePreferences } from '../../lib/preferences'
-import {
-  getGenericShortcutString,
-  KeymapItem,
-  KeymapItemEditableProps,
-} from '../../lib/keymap'
+import { getGenericShortcutString, KeymapItem } from '../../lib/keymap'
 import { useTranslation } from 'react-i18next'
 import KeymapItemSection from '../atoms/KeymapItemSection'
 import styled from '../../lib/styled/styled'
@@ -28,28 +24,6 @@ const KeymapTab = () => {
     }
   }, [preferences])
 
-  const handleAssignNewKeymap = useCallback(
-    (
-      key: string,
-      firstShortcut: KeymapItemEditableProps,
-      secondShortcut?: KeymapItemEditableProps
-    ) => {
-      return updateKeymap(key, firstShortcut, secondShortcut)
-    },
-    [updateKeymap]
-  )
-
-  const handleRemoveKeymap = useCallback(
-    (key: string) => {
-      removeKeymap(key)
-    },
-    [removeKeymap]
-  )
-
-  const handleResetKeymap = useCallback(() => {
-    resetKeymap()
-  }, [resetKeymap])
-
   const getKeymapItemSectionKey = useCallback((keymapItem: KeymapItem) => {
     if (keymapItem.shortcutMainStroke == null) {
       return keymapItem.description
@@ -63,7 +37,7 @@ const KeymapTab = () => {
       <KeymapHeaderSection>
         <SectionHeader>{t('preferences.keymap')}</SectionHeader>
         <SectionResetKeymap>
-          <ButtonContainer onClick={handleResetKeymap}>Reset</ButtonContainer>
+          <ButtonContainer onClick={() => resetKeymap()}>Reset</ButtonContainer>
         </SectionResetKeymap>
       </KeymapHeaderSection>
       <KeymapItemList>
@@ -75,8 +49,8 @@ const KeymapTab = () => {
                 keymapKey={keymapEntry[0]}
                 currentKeymapItem={keymapEntry[1].shortcutMainStroke}
                 description={keymapEntry[1].description}
-                onAssignNewKeymap={handleAssignNewKeymap}
-                removeKeymap={handleRemoveKeymap}
+                updateKeymap={updateKeymap}
+                removeKeymap={removeKeymap}
               />
             )
           })}

--- a/src/components/PreferencesModal/KeymapTab.tsx
+++ b/src/components/PreferencesModal/KeymapTab.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useMemo } from 'react'
 import { Section, SectionHeader } from './styled'
 import { usePreferences } from '../../lib/preferences'
-import { KeymapItem, KeymapItemEditableProps } from '../../lib/keymap'
+import {
+  getGenericShortcutString,
+  KeymapItem,
+  KeymapItemEditableProps,
+} from '../../lib/keymap'
 import { useTranslation } from 'react-i18next'
 import KeymapItemSection from '../atoms/KeymapItemSection'
 import styled from '../../lib/styled/styled'
@@ -46,6 +50,14 @@ const KeymapTab = () => {
     resetKeymap()
   }, [resetKeymap])
 
+  const getKeymapItemSectionKey = useCallback((keymapItem: KeymapItem) => {
+    if (keymapItem.shortcutMainStroke == null) {
+      return keymapItem.description
+    } else {
+      return getGenericShortcutString(keymapItem.shortcutMainStroke)
+    }
+  }, [])
+
   return (
     <Section>
       <KeymapHeaderSection>
@@ -59,7 +71,7 @@ const KeymapTab = () => {
           keymap.map((keymapEntry: [string, KeymapItem]) => {
             return (
               <KeymapItemSection
-                key={keymapEntry[0]}
+                key={getKeymapItemSectionKey(keymapEntry[1])}
                 keymapKey={keymapEntry[0]}
                 currentKeymapItem={keymapEntry[1].shortcutMainStroke}
                 description={keymapEntry[1].description}

--- a/src/components/PreferencesModal/KeymapTab.tsx
+++ b/src/components/PreferencesModal/KeymapTab.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useMemo } from 'react'
+import { Section, SectionHeader } from './styled'
+import { usePreferences } from '../../lib/preferences'
+import { KeymapItem, KeymapItemEditableProps } from '../../lib/keymap'
+import { useTranslation } from 'react-i18next'
+import KeymapItemSection from '../atoms/KeymapItemSection'
+import styled from '../../lib/styled/styled'
+
+const KeymapTab = () => {
+  const {
+    preferences,
+    updateKeymap,
+    removeKeymap,
+    resetKeymap,
+  } = usePreferences()
+  const { t } = useTranslation()
+
+  const keymap = useMemo(() => {
+    const keymap = preferences['general.keymap']
+    if (keymap != null) {
+      return [...keymap.entries()]
+    } else {
+      return []
+    }
+  }, [preferences])
+
+  const handleAssignNewKeymap = useCallback(
+    (
+      key: string,
+      firstShortcut: KeymapItemEditableProps,
+      secondShortcut?: KeymapItemEditableProps
+    ) => {
+      return updateKeymap(key, firstShortcut, secondShortcut)
+    },
+    [updateKeymap]
+  )
+
+  const handleRemoveKeymap = useCallback(
+    (key: string) => {
+      removeKeymap(key)
+    },
+    [removeKeymap]
+  )
+
+  const handleResetKeymap = useCallback(() => {
+    resetKeymap()
+  }, [resetKeymap])
+
+  return (
+    <Section>
+      <KeymapHeaderSection>
+        <SectionHeader>{t('preferences.keymap')}</SectionHeader>
+        <SectionResetKeymap>
+          <ButtonContainer onClick={handleResetKeymap}>Reset</ButtonContainer>
+        </SectionResetKeymap>
+      </KeymapHeaderSection>
+      <KeymapItemList>
+        {keymap != null &&
+          keymap.map((keymapEntry: [string, KeymapItem]) => {
+            return (
+              <KeymapItemSection
+                key={keymapEntry[0]}
+                keymapKey={keymapEntry[0]}
+                currentKeymapItem={keymapEntry[1].shortcutMainStroke}
+                description={keymapEntry[1].description}
+                onAssignNewKeymap={handleAssignNewKeymap}
+                removeKeymap={handleRemoveKeymap}
+              />
+            )
+          })}
+      </KeymapItemList>
+    </Section>
+  )
+}
+
+const KeymapItemList = styled.div`
+  display: grid;
+  grid-template-rows: auto;
+  row-gap: 0.5em;
+`
+
+const KeymapHeaderSection = styled.div`
+  display: grid;
+  grid-template-columns: auto auto;
+`
+
+const SectionResetKeymap = styled.div`
+  margin-left: auto;
+  align-self: center;
+`
+
+export const ButtonContainer = styled.button`
+  width: 92px;
+  height: 32px;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+
+  background: #214953;
+  border: 1px solid #214953;
+  border-radius: 4px;
+
+  transition: color 200ms ease-in-out;
+  color: ${({ theme }) => theme.navButtonColor};
+  &:hover {
+    color: ${({ theme }) => theme.navButtonHoverColor};
+  }
+
+  &:active,
+  &.active {
+    color: ${({ theme }) => theme.navButtonActiveColor};
+  }
+
+  &.disabled,
+  &:disabled {
+    color: ${({ theme }) => theme.disabledUiTextColor};
+    background: #12292e;
+    border: 1px solid #214953;
+    border-radius: 4px;
+    width: 88px;
+    height: 32px;
+  }
+`
+
+export default KeymapTab

--- a/src/components/PreferencesModal/PreferencesModal.tsx
+++ b/src/components/PreferencesModal/PreferencesModal.tsx
@@ -23,6 +23,7 @@ import { useRouteParams } from '../../lib/routeParams'
 import StorageTab from './StorageTab'
 import MigrationPage from './MigrationTab'
 import { useMigrations } from '../../lib/migrate/store'
+import KeymapTab from './KeymapTab'
 
 const FullScreenContainer = styled.div`
   z-index: 7000;
@@ -58,7 +59,7 @@ const ContentContainer = styled.div`
 
 const ModalHeader = styled.div`
   height: 40px;
-  ${borderBottom}
+  ${borderBottom};
   display: flex;
 `
 
@@ -136,6 +137,8 @@ const PreferencesModal = () => {
 
   const content = useMemo(() => {
     switch (tab) {
+      case 'keymap':
+        return <KeymapTab />
       case 'editor':
         return <EditorTab />
       case 'markdown':
@@ -146,14 +149,17 @@ const PreferencesModal = () => {
         if (currentStorage != null) {
           return <StorageTab storage={currentStorage} />
         }
+        break
       case 'migration':
         if (currentStorage != null) {
           return <MigrationPage storage={currentStorage} />
         }
+        break
       case 'general':
       default:
         return <GeneralTab />
     }
+    return <GeneralTab />
   }, [tab, currentStorage])
 
   if (closed) {
@@ -178,6 +184,12 @@ const PreferencesModal = () => {
               label={t('about.about')}
               tab='about'
               active={tab === 'about'}
+              setTab={openTab}
+            />
+            <TabButton
+              label={t('preferences.keymap')}
+              tab='keymap'
+              active={tab === 'keymap'}
               setTab={openTab}
             />
             <TabButton

--- a/src/components/PreferencesModal/PreferencesModal.tsx
+++ b/src/components/PreferencesModal/PreferencesModal.tsx
@@ -155,9 +155,6 @@ const PreferencesModal = () => {
           return <MigrationPage storage={currentStorage} />
         }
         break
-      case 'general':
-      default:
-        return <GeneralTab />
     }
     return <GeneralTab />
   }, [tab, currentStorage])

--- a/src/components/atoms/CodeEditor.tsx
+++ b/src/components/atoms/CodeEditor.tsx
@@ -150,7 +150,6 @@ class CodeEditor extends React.Component<CodeEditorProps> {
       this.codeMirror.setOption('keyMap', keyMap)
     }
 
-    // Update shortcut binding
     this.codeMirror.setOption('extraKeys', this.getExtraKeys())
   }
 

--- a/src/components/atoms/CustomizedCodeEditor.tsx
+++ b/src/components/atoms/CustomizedCodeEditor.tsx
@@ -28,7 +28,7 @@ const CustomizedCodeEditor = ({
   onDrop,
   onCursorActivity,
 }: CustomizedCodeEditorProps) => {
-  const { preferences } = usePreferences()
+  const { preferences, getCodemirrorTypeKeymap } = usePreferences()
   return (
     <CodeEditor
       onChange={onChange}
@@ -41,6 +41,7 @@ const CustomizedCodeEditor = ({
       indentType={preferences['editor.indentType']}
       indentSize={preferences['editor.indentSize']}
       keyMap={preferences['editor.keyMap']}
+      getCustomKeymap={getCodemirrorTypeKeymap}
       mode={mode}
       readonly={readonly}
       onPaste={onPaste}

--- a/src/components/atoms/KeymapItemSection.tsx
+++ b/src/components/atoms/KeymapItemSection.tsx
@@ -1,0 +1,234 @@
+import React, {
+  KeyboardEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import styled from '../../lib/styled'
+import {
+  getGenericShortcutString,
+  KeymapItemEditableProps,
+} from '../../lib/keymap'
+import { inputStyle } from '../../lib/styled/styleFunctions'
+import cc from 'classcat'
+import { useToast } from '../../lib/toast'
+import { ButtonContainer } from '../PreferencesModal/KeymapTab'
+
+const invalidShortcutInputs = [' ']
+const rejectedShortcutInputs = [' ', 'control', 'alt', 'shift']
+
+interface KeymapItemSectionProps {
+  keymapKey: string
+  currentKeymapItem?: KeymapItemEditableProps
+  onAssignNewKeymap: (
+    key: string,
+    shortcutFirst: KeymapItemEditableProps,
+    shortcutSecond?: KeymapItemEditableProps
+  ) => Promise<void>
+  removeKeymap: (key: string) => void
+  description: string
+}
+
+const KeymapItemSection = ({
+  keymapKey,
+  currentKeymapItem,
+  onAssignNewKeymap,
+  removeKeymap,
+  description,
+}: KeymapItemSectionProps) => {
+  const [inputError, setInputError] = useState<boolean>(false)
+  const [shortcutInputValue, setShortcutInputValue] = useState<string>('')
+  const [changingShortcut, setChangingShortcut] = useState<boolean>(false)
+  const [
+    currentShortcut,
+    setCurrentShortcut,
+  ] = useState<KeymapItemEditableProps | null>(
+    currentKeymapItem != null ? currentKeymapItem : null
+  )
+  const [
+    previousShortcut,
+    setPreviousShortcut,
+  ] = useState<KeymapItemEditableProps | null>(null)
+  const shortcutInputRef = useRef<HTMLInputElement>(null)
+
+  const { pushMessage } = useToast()
+
+  const fetchInputShortcuts: KeyboardEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    event.stopPropagation()
+    event.preventDefault()
+    if (invalidShortcutInputs.includes(event.key.toLowerCase())) {
+      setInputError(true)
+      return
+    }
+
+    setInputError(false)
+    const shortcut: KeymapItemEditableProps = {
+      key: event.key.toUpperCase(),
+      keycode: event.keyCode,
+      modifiers: {
+        ctrl: event.ctrlKey,
+        alt: event.altKey,
+        shift: event.shiftKey,
+      },
+    }
+    setCurrentShortcut(shortcut)
+    setShortcutInputValue(getGenericShortcutString(shortcut))
+  }
+
+  const applyKeymap = useCallback(() => {
+    if (currentShortcut != null) {
+      if (rejectedShortcutInputs.includes(currentShortcut.key.toLowerCase())) {
+        setInputError(true)
+        if (shortcutInputRef.current != null) {
+          shortcutInputRef.current.focus()
+        }
+        return
+      }
+
+      onAssignNewKeymap(keymapKey, currentShortcut, undefined)
+        .then(() => {
+          setChangingShortcut(false)
+          setInputError(false)
+        })
+        .catch(() => {
+          pushMessage({
+            title: 'Keymap assignment failed',
+            description: 'Cannot assign to already assigned shortcut',
+          })
+          setInputError(true)
+        })
+    }
+  }, [currentShortcut, keymapKey, onAssignNewKeymap, pushMessage])
+
+  const toggleChangingShortcut = useCallback(() => {
+    if (changingShortcut) {
+      applyKeymap()
+    } else {
+      setChangingShortcut(true)
+      setPreviousShortcut(currentShortcut)
+      if (currentShortcut != null) {
+        setShortcutInputValue(getGenericShortcutString(currentShortcut))
+      }
+    }
+  }, [applyKeymap, currentShortcut, changingShortcut])
+
+  const handleCancelKeymapChange = useCallback(() => {
+    setCurrentShortcut(previousShortcut)
+    setChangingShortcut(false)
+    setShortcutInputValue('')
+    setInputError(false)
+  }, [previousShortcut])
+
+  const handleRemoveKeymap = useCallback(() => {
+    setCurrentShortcut(null)
+    setPreviousShortcut(null)
+    setShortcutInputValue('')
+    removeKeymap(keymapKey)
+  }, [keymapKey, removeKeymap])
+
+  const shortcutString = useMemo(() => {
+    return currentShortcut != null
+      ? getGenericShortcutString(currentShortcut)
+      : ''
+  }, [currentShortcut])
+  return (
+    <KeymapItemSectionContainer>
+      <div>{description}</div>
+      <KeymapItemInputSection>
+        {changingShortcut && (
+          <StyledInput
+            className={cc([inputError && 'error'])}
+            placeholder={'Press key'}
+            autoFocus={true}
+            ref={shortcutInputRef}
+            value={shortcutInputValue}
+            onKeyDown={fetchInputShortcuts}
+          />
+        )}
+
+        <InputKeymapChooser onClick={toggleChangingShortcut}>
+          {currentShortcut == null
+            ? 'Assign'
+            : changingShortcut
+            ? 'Apply'
+            : shortcutString}
+        </InputKeymapChooser>
+        {changingShortcut && (
+          <ButtonContainer onClick={handleCancelKeymapChange}>
+            Cancel
+          </ButtonContainer>
+        )}
+
+        {currentShortcut != null && !changingShortcut && (
+          <ButtonContainer onClick={handleRemoveKeymap}>
+            Un-assign
+          </ButtonContainer>
+        )}
+      </KeymapItemInputSection>
+    </KeymapItemSectionContainer>
+  )
+}
+
+const StyledInput = styled.input`
+  ${inputStyle};
+  max-width: 120px;
+  min-width: 110px;
+  height: 1.3em;
+
+  &.error {
+    border: 1px solid red;
+  }
+`
+
+const InputKeymapChooser = styled.button`
+  min-width: 88px;
+  max-width: 120px;
+  height: 32px;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+
+  background: #214953;
+  border: 1px solid #214953;
+  border-radius: 4px;
+
+  transition: color 200ms ease-in-out;
+  color: ${({ theme }) => theme.navButtonColor};
+
+  text-align: center;
+  //padding: 8px 0;
+  padding: 5px;
+
+  &:hover {
+    background: #2a5c69;
+  }
+`
+
+const KeymapItemSectionContainer = styled.div`
+  display: grid;
+  grid-template-columns: 45% minmax(55%, 400px);
+
+  //margin-left: 15%;
+  //margin-right: 15%;
+`
+
+const KeymapItemInputSection = styled.div`
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+
+  max-width: 380px;
+  justify-items: left;
+
+  margin-right: auto;
+
+  column-gap: 1em;
+`
+
+export default KeymapItemSection

--- a/src/components/atoms/KeymapItemSection.tsx
+++ b/src/components/atoms/KeymapItemSection.tsx
@@ -21,7 +21,7 @@ const rejectedShortcutInputs = [' ', 'control', 'alt', 'shift']
 interface KeymapItemSectionProps {
   keymapKey: string
   currentKeymapItem?: KeymapItemEditableProps
-  onAssignNewKeymap: (
+  updateKeymap: (
     key: string,
     shortcutFirst: KeymapItemEditableProps,
     shortcutSecond?: KeymapItemEditableProps
@@ -33,7 +33,7 @@ interface KeymapItemSectionProps {
 const KeymapItemSection = ({
   keymapKey,
   currentKeymapItem,
-  onAssignNewKeymap,
+  updateKeymap,
   removeKeymap,
   description,
 }: KeymapItemSectionProps) => {
@@ -79,29 +79,30 @@ const KeymapItemSection = ({
   }
 
   const applyKeymap = useCallback(() => {
-    if (currentShortcut != null) {
-      if (rejectedShortcutInputs.includes(currentShortcut.key.toLowerCase())) {
-        setInputError(true)
-        if (shortcutInputRef.current != null) {
-          shortcutInputRef.current.focus()
-        }
-        return
-      }
-
-      onAssignNewKeymap(keymapKey, currentShortcut, undefined)
-        .then(() => {
-          setChangingShortcut(false)
-          setInputError(false)
-        })
-        .catch(() => {
-          pushMessage({
-            title: 'Keymap assignment failed',
-            description: 'Cannot assign to already assigned shortcut',
-          })
-          setInputError(true)
-        })
+    if (currentShortcut == null) {
+      return
     }
-  }, [currentShortcut, keymapKey, onAssignNewKeymap, pushMessage])
+    if (rejectedShortcutInputs.includes(currentShortcut.key.toLowerCase())) {
+      setInputError(true)
+      if (shortcutInputRef.current != null) {
+        shortcutInputRef.current.focus()
+      }
+      return
+    }
+
+    updateKeymap(keymapKey, currentShortcut, undefined)
+      .then(() => {
+        setChangingShortcut(false)
+        setInputError(false)
+      })
+      .catch(() => {
+        pushMessage({
+          title: 'Keymap assignment failed',
+          description: 'Cannot assign to already assigned shortcut',
+        })
+        setInputError(true)
+      })
+  }, [currentShortcut, keymapKey, updateKeymap, pushMessage])
 
   const toggleChangingShortcut = useCallback(() => {
     if (changingShortcut) {
@@ -202,7 +203,6 @@ const InputKeymapChooser = styled.button`
   color: ${({ theme }) => theme.navButtonColor};
 
   text-align: center;
-  //padding: 8px 0;
   padding: 5px;
 
   &:hover {
@@ -213,9 +213,6 @@ const InputKeymapChooser = styled.button`
 const KeymapItemSectionContainer = styled.div`
   display: grid;
   grid-template-columns: 45% minmax(55%, 400px);
-
-  //margin-left: 15%;
-  //margin-right: 15%;
 `
 
 const KeymapItemInputSection = styled.div`

--- a/src/components/organisms/NoteStorageNavigator.tsx
+++ b/src/components/organisms/NoteStorageNavigator.tsx
@@ -22,6 +22,7 @@ import { flexCenter, textOverflow } from '../../lib/styled/styleFunctions'
 import { noteDetailFocusTitleInputEventEmitter } from '../../lib/events'
 import NavigatorSeparator from '../atoms/NavigatorSeparator'
 import { useTranslation } from 'react-i18next'
+import { useSearchModal } from '../../lib/searchModal'
 
 interface NoteStorageNavigatorProps {
   storage: NoteStorage
@@ -229,6 +230,18 @@ const NoteStorageNavigator = ({ storage }: NoteStorageNavigatorProps) => {
       removeIpcListener('new-note', handler)
     }
   }, [createNoteByRoute])
+
+  const { toggleShowSearchModal } = useSearchModal()
+
+  useEffect(() => {
+    const handler = () => {
+      toggleShowSearchModal()
+    }
+    addIpcListener('search', handler)
+    return () => {
+      removeIpcListener('search', handler)
+    }
+  }, [toggleShowSearchModal])
 
   return (
     <NavigatorContainer onContextMenu={openStorageContextMenu}>

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -1,7 +1,13 @@
-import { app, shell, MenuItemConstructorOptions } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  MenuItem,
+  MenuItemConstructorOptions,
+  shell,
+} from 'electron'
 import { checkForUpdates } from './updater'
 import { createEmitIpcMenuItemHandler } from './ipc'
-import { MenuItem, BrowserWindow } from 'electron'
+
 const mac = process.platform === 'darwin'
 
 function createSwitchWorkspaceHandler(index: number) {
@@ -16,18 +22,93 @@ function createSwitchWorkspaceHandler(index: number) {
   }
 }
 
-export const template: MenuItemConstructorOptions[] = [
-  ...(mac
-    ? [
-        {
-          label: app.getName(),
-          submenu: [
-            { role: 'about' },
+export function getTemplateFromKeymap(
+  keymap: Map<string, string>
+): MenuItemConstructorOptions[] {
+  return [
+    ...(mac
+      ? [
+          {
+            label: app.getName(),
+            submenu: [
+              { role: 'about' },
+              { type: 'separator' },
+              {
+                label: 'Preferences',
+                accelerator: 'Cmd+,',
+                click: createEmitIpcMenuItemHandler('preferences'),
+              },
+              { type: 'separator' },
+              {
+                label: 'Add Cloud Space',
+                click: createEmitIpcMenuItemHandler('create-cloud-space'),
+              },
+              {
+                label: 'Add Local Space',
+                click: createEmitIpcMenuItemHandler('create-local-space'),
+              },
+              { type: 'separator' },
+              {
+                label: 'Check For Updates',
+                click: checkForUpdates,
+              },
+              { type: 'separator' },
+              { role: 'services' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideothers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' },
+            ] as MenuItemConstructorOptions[],
+          },
+        ]
+      : []),
+    {
+      label: 'File',
+      submenu: mac
+        ? [
+            {
+              type: 'normal',
+              label: 'New Note',
+              click: createEmitIpcMenuItemHandler('new-note'),
+              accelerator: 'Cmd + N',
+            },
+            {
+              type: 'normal',
+              label: 'New Folder',
+              click: createEmitIpcMenuItemHandler('new-folder'),
+              accelerator: 'Cmd + Shift + N',
+            },
             { type: 'separator' },
             {
-              label: 'Preferences',
-              accelerator: 'Cmd+,',
-              click: createEmitIpcMenuItemHandler('preferences'),
+              type: 'normal',
+              label: 'Save As',
+              click: createEmitIpcMenuItemHandler('save-as'),
+              accelerator: keymap.get('editorSaveAs'),
+            },
+            { type: 'separator' },
+            { role: 'close' },
+          ]
+        : ([
+            {
+              type: 'normal',
+              label: 'New Note',
+              click: createEmitIpcMenuItemHandler('new-note'),
+              accelerator: 'Ctrl + N',
+            },
+            {
+              type: 'normal',
+              label: 'New Folder',
+              click: createEmitIpcMenuItemHandler('new-folder'),
+              accelerator: 'Ctrl + Shift + N',
+            },
+            { type: 'separator' },
+            {
+              type: 'normal',
+              label: 'Save As',
+              click: createEmitIpcMenuItemHandler('save-as'),
+              accelerator: keymap.get('editorSaveAs'),
             },
             { type: 'separator' },
             {
@@ -44,325 +125,258 @@ export const template: MenuItemConstructorOptions[] = [
               click: checkForUpdates,
             },
             { type: 'separator' },
-            { role: 'services' },
-            { type: 'separator' },
-            { role: 'hide' },
-            { role: 'hideothers' },
-            { role: 'unhide' },
+            {
+              label: 'Preferences',
+              accelerator: 'Ctrl+,',
+              click: createEmitIpcMenuItemHandler('preferences'),
+            },
             { type: 'separator' },
             { role: 'quit' },
-          ] as MenuItemConstructorOptions[],
-        },
-      ]
-    : []),
-  {
-    label: 'File',
-    submenu: mac
-      ? [
-          {
-            type: 'normal',
-            label: 'New Note',
-            click: createEmitIpcMenuItemHandler('new-note'),
-            accelerator: 'Cmd + N',
-          },
-          {
-            type: 'normal',
-            label: 'New Folder',
-            click: createEmitIpcMenuItemHandler('new-folder'),
-            accelerator: 'Cmd + Shift + N',
-          },
-          { type: 'separator' },
-          {
-            type: 'normal',
-            label: 'Save As',
-            click: createEmitIpcMenuItemHandler('save-as'),
-            accelerator: 'Cmd + S',
-          },
-          { type: 'separator' },
-          { role: 'close' },
-        ]
-      : ([
-          {
-            type: 'normal',
-            label: 'New Note',
-            click: createEmitIpcMenuItemHandler('new-note'),
-            accelerator: 'Ctrl + N',
-          },
-          {
-            type: 'normal',
-            label: 'New Folder',
-            click: createEmitIpcMenuItemHandler('new-folder'),
-            accelerator: 'Ctrl + Shift + N',
-          },
-          { type: 'separator' },
-          {
-            type: 'normal',
-            label: 'Save As',
-            click: createEmitIpcMenuItemHandler('save-as'),
-            accelerator: 'Ctrl + S',
-          },
-          { type: 'separator' },
-          {
-            label: 'Add Cloud Space',
-            click: createEmitIpcMenuItemHandler('create-cloud-space'),
-          },
-          {
-            label: 'Add Local Space',
-            click: createEmitIpcMenuItemHandler('create-local-space'),
-          },
-          { type: 'separator' },
-          {
-            label: 'Check For Updates',
-            click: checkForUpdates,
-          },
-          { type: 'separator' },
-          {
-            label: 'Preferences',
-            accelerator: 'Ctrl+,',
-            click: createEmitIpcMenuItemHandler('preferences'),
-          },
-          { type: 'separator' },
-          { role: 'quit' },
-        ] as MenuItemConstructorOptions[]),
-  },
-  {
-    label: 'Edit',
-    submenu: [
-      {
-        label: 'Format',
-        type: 'submenu',
-        submenu: [
-          {
-            type: 'normal',
-            label: 'Bold',
-            click: createEmitIpcMenuItemHandler('apply-bold-style'),
-            accelerator: mac ? 'Cmd + B' : 'Ctrl + B',
-          },
-          {
-            type: 'normal',
-            label: 'Italic',
-            click: createEmitIpcMenuItemHandler('apply-italic-style'),
-            accelerator: mac ? 'Cmd + I' : 'Ctrl + I',
-          },
-        ],
-      },
-      { type: 'separator' },
-      { role: 'undo' },
-      { role: 'redo' },
-      { type: 'separator' },
-      { role: 'cut' },
-      { role: 'copy' },
-      { role: 'paste' },
-      { type: 'separator' },
-      {
-        type: 'normal',
-        label: 'Search',
-        click: createEmitIpcMenuItemHandler('search'),
-        accelerator: mac ? 'Cmd + P' : 'Ctrl + P',
-      },
-      // {
-      //   type: 'normal',
-      //   label: 'Toggle Bookmark',
-      //   click: createEmitIpcMenuItemHandler('toggle-bookmark'),
-      //   accelerator: mac ? 'Cmd + D' : 'Ctrl + D',
-      // },
-      { type: 'separator' },
-      ...(mac
-        ? [
-            { role: 'pasteAndMatchStyle' },
-            { role: 'delete' },
-            { role: 'selectAll' },
-            { type: 'separator' },
+          ] as MenuItemConstructorOptions[]),
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        {
+          label: 'Format',
+          type: 'submenu',
+          submenu: [
             {
-              label: 'Speech',
-              submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+              type: 'normal',
+              label: 'Bold',
+              click: createEmitIpcMenuItemHandler('apply-bold-style'),
+              accelerator: mac ? 'Cmd + B' : 'Ctrl + B',
             },
-          ]
-        : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
-    ] as MenuItemConstructorOptions[],
-  },
-  {
-    label: 'View',
-    submenu: [
-      {
-        type: 'submenu',
-        label: 'Switch Workspace',
-        submenu: [
-          {
-            type: 'normal',
-            label: 'Switch to First Workspace',
-            accelerator: mac ? 'Cmd + 1' : 'Ctrl + 1',
-            click: createSwitchWorkspaceHandler(0),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to Second Workspace',
-            accelerator: mac ? 'Cmd + 2' : 'Ctrl + 2',
-            click: createSwitchWorkspaceHandler(1),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to Third Workspace',
-            accelerator: mac ? 'Cmd + 3' : 'Ctrl + 3',
-            click: createSwitchWorkspaceHandler(2),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to 4th Workspace',
-            accelerator: mac ? 'Cmd + 4' : 'Ctrl + 4',
-            click: createSwitchWorkspaceHandler(3),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to 5th Workspace',
-            accelerator: mac ? 'Cmd + 5' : 'Ctrl + 5',
-            click: createSwitchWorkspaceHandler(4),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to 6th Workspace',
-            accelerator: mac ? 'Cmd + 6' : 'Ctrl + 6',
-            click: createSwitchWorkspaceHandler(5),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to 7th Workspace',
-            accelerator: mac ? 'Cmd + 7' : 'Ctrl + 7',
-            click: createSwitchWorkspaceHandler(6),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to 8th Workspace',
-            accelerator: mac ? 'Cmd + 8' : 'Ctrl + 8',
-            click: createSwitchWorkspaceHandler(7),
-          },
-          {
-            type: 'normal',
-            label: 'Switch to 9th Workspace',
-            accelerator: mac ? 'Cmd + 9' : 'Ctrl + 9',
-            click: createSwitchWorkspaceHandler(8),
-          },
-        ],
-      },
-      // {
-      //   type: 'normal',
-      //   label: 'Focus On Side Navigator',
-      //   click: createEmitIpcMenuItemHandler('focus-side-navigator'),
-      //   accelerator: mac ? 'Cmd + 0' : 'Ctrl + 0',
-      // },
-      {
-        type: 'normal',
-        label: 'Toggle Side Navigator',
-        click: createEmitIpcMenuItemHandler('toggle-side-navigator'),
-        accelerator: mac ? 'Cmd + Shift + 0' : 'Ctrl + Shift + 0',
-      },
-      { type: 'separator' },
-      {
-        type: 'normal',
-        label: 'Focus On Editor',
-        click: createEmitIpcMenuItemHandler('focus-editor'),
-        accelerator: mac ? 'Cmd + J' : 'Ctrl + J',
-      },
-      {
-        type: 'normal',
-        label: 'Focus On Title',
-        click: createEmitIpcMenuItemHandler('focus-title'),
-        accelerator: mac ? 'Cmd +Shift+ J' : 'Ctrl+Shift + J',
-      },
-      { type: 'separator' },
-      {
-        type: 'normal',
-        label: 'Toggle Preview Mode',
-        click: createEmitIpcMenuItemHandler('toggle-preview-mode'),
-        accelerator: mac ? 'Cmd + E' : 'Ctrl + E',
-      },
-      {
-        type: 'normal',
-        label: 'Toggle Split Edit Mode',
-        click: createEmitIpcMenuItemHandler('toggle-split-edit-mode'),
-        accelerator: mac ? 'Cmd + \\' : 'Ctrl + \\',
-      },
-      { type: 'separator' },
-      { role: 'reload' },
-      { role: 'forcereload' },
-      { role: 'toggledevtools' },
-      { type: 'separator' },
-      // { role: 'resetzoom' },
-      // { role: 'zoomin' },
-      // { role: 'zoomout' },
-      // { type: 'separator' },
-      { role: 'togglefullscreen' },
-    ] as MenuItemConstructorOptions[],
-  },
-  {
-    label: 'Window',
-    submenu: [
-      { role: 'minimize' },
-      { role: 'zoom' },
-      ...(mac
-        ? [
-            { type: 'separator' },
-            { role: 'front' },
-            { type: 'separator' },
-            { role: 'window' },
-          ]
-        : [{ role: 'close' }]),
-    ] as MenuItemConstructorOptions[],
-  },
-  {
-    label: 'Community',
-    submenu: [
-      {
-        label: 'GitHub',
-        click: async () => {
-          await shell.openExternal('https://github.com/BoostIO/Boostnote.next')
+            {
+              type: 'normal',
+              label: 'Italic',
+              click: createEmitIpcMenuItemHandler('apply-italic-style'),
+              accelerator: mac ? 'Cmd + I' : 'Ctrl + I',
+            },
+          ],
         },
-      },
-      {
-        label: 'Slack',
-        click: async () => {
-          await shell.openExternal(
-            'https://join.slack.com/t/boostnote-group/shared_invite/zt-cun7pas3-WwkaezxHBB1lCbUHrwQLXw'
-          )
+        { type: 'separator' },
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { type: 'separator' },
+        {
+          type: 'normal',
+          label: 'Search',
+          click: createEmitIpcMenuItemHandler('search'),
+          accelerator: keymap.get('toggleGlobalSearch'),
         },
-      },
-      {
-        label: 'IssueHunt',
-        click: async () => {
-          await shell.openExternal(
-            'https://issuehunt.io/r/BoostIo/Boostnote.next'
-          )
+        // {
+        //   type: 'normal',
+        //   label: 'Toggle Bookmark',
+        //   click: createEmitIpcMenuItemHandler('toggle-bookmark'),
+        //   accelerator: mac ? 'Cmd + D' : 'Ctrl + D',
+        // },
+        { type: 'separator' },
+        ...(mac
+          ? [
+              { role: 'pasteAndMatchStyle' },
+              { role: 'delete' },
+              { role: 'selectAll' },
+              { type: 'separator' },
+              {
+                label: 'Speech',
+                submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }],
+              },
+            ]
+          : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
+      ] as MenuItemConstructorOptions[],
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          type: 'submenu',
+          label: 'Switch Workspace',
+          submenu: [
+            {
+              type: 'normal',
+              label: 'Switch to First Workspace',
+              accelerator: mac ? 'Cmd + 1' : 'Ctrl + 1',
+              click: createSwitchWorkspaceHandler(0),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to Second Workspace',
+              accelerator: mac ? 'Cmd + 2' : 'Ctrl + 2',
+              click: createSwitchWorkspaceHandler(1),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to Third Workspace',
+              accelerator: mac ? 'Cmd + 3' : 'Ctrl + 3',
+              click: createSwitchWorkspaceHandler(2),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to 4th Workspace',
+              accelerator: mac ? 'Cmd + 4' : 'Ctrl + 4',
+              click: createSwitchWorkspaceHandler(3),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to 5th Workspace',
+              accelerator: mac ? 'Cmd + 5' : 'Ctrl + 5',
+              click: createSwitchWorkspaceHandler(4),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to 6th Workspace',
+              accelerator: mac ? 'Cmd + 6' : 'Ctrl + 6',
+              click: createSwitchWorkspaceHandler(5),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to 7th Workspace',
+              accelerator: mac ? 'Cmd + 7' : 'Ctrl + 7',
+              click: createSwitchWorkspaceHandler(6),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to 8th Workspace',
+              accelerator: mac ? 'Cmd + 8' : 'Ctrl + 8',
+              click: createSwitchWorkspaceHandler(7),
+            },
+            {
+              type: 'normal',
+              label: 'Switch to 9th Workspace',
+              accelerator: mac ? 'Cmd + 9' : 'Ctrl + 9',
+              click: createSwitchWorkspaceHandler(8),
+            },
+          ],
         },
-      },
-      {
-        label: 'Twitter',
-        click: async () => {
-          await shell.openExternal('https://twitter.com/boostnoteapp')
+        // {
+        //   type: 'normal',
+        //   label: 'Focus On Side Navigator',
+        //   click: createEmitIpcMenuItemHandler('focus-side-navigator'),
+        //   accelerator: mac ? 'Cmd + 0' : 'Ctrl + 0',
+        // },
+        {
+          type: 'normal',
+          label: 'Toggle Side Navigator',
+          click: createEmitIpcMenuItemHandler('toggle-side-navigator'),
+          accelerator: mac ? 'Cmd + Shift + 0' : 'Ctrl + Shift + 0',
         },
-      },
-      {
-        label: 'Facebook',
-        click: async () => {
-          await shell.openExternal('https://www.facebook.com/groups/boostnote/')
+        { type: 'separator' },
+        {
+          type: 'normal',
+          label: 'Focus On Editor',
+          click: createEmitIpcMenuItemHandler('focus-editor'),
+          accelerator: mac ? 'Cmd + J' : 'Ctrl + J',
         },
-      },
-      {
-        label: 'Reddit',
-        click: async () => {
-          await shell.openExternal('https://www.reddit.com/r/Boostnote/')
+        {
+          type: 'normal',
+          label: 'Focus On Title',
+          click: createEmitIpcMenuItemHandler('focus-title'),
+          accelerator: mac ? 'Cmd +Shift+ J' : 'Ctrl+Shift + J',
         },
-      },
-    ] as MenuItemConstructorOptions[],
-  },
-  {
-    role: 'help',
-    submenu: [
-      {
-        label: 'Learn More',
-        click: async () => {
-          await shell.openExternal('https://boosthub.io')
+        { type: 'separator' },
+        {
+          type: 'normal',
+          label: 'Toggle Preview Mode',
+          click: createEmitIpcMenuItemHandler('toggle-preview-mode'),
+          accelerator: keymap.get('togglePreviewMode'),
         },
-      },
-    ] as MenuItemConstructorOptions[],
-  },
-]
+        {
+          type: 'normal',
+          label: 'Toggle Split Edit Mode',
+          click: createEmitIpcMenuItemHandler('toggle-split-edit-mode'),
+          accelerator: keymap.get('toggleSplitEditMode'),
+        },
+        { type: 'separator' },
+        { role: 'reload' },
+        { role: 'forcereload' },
+        { role: 'toggledevtools' },
+        { type: 'separator' },
+        // { role: 'resetzoom' },
+        // { role: 'zoomin' },
+        // { role: 'zoomout' },
+        // { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ] as MenuItemConstructorOptions[],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(mac
+          ? [
+              { type: 'separator' },
+              { role: 'front' },
+              { type: 'separator' },
+              { role: 'window' },
+            ]
+          : [{ role: 'close' }]),
+      ] as MenuItemConstructorOptions[],
+    },
+    {
+      label: 'Community',
+      submenu: [
+        {
+          label: 'GitHub',
+          click: async () => {
+            await shell.openExternal(
+              'https://github.com/BoostIO/Boostnote.next'
+            )
+          },
+        },
+        {
+          label: 'Slack',
+          click: async () => {
+            await shell.openExternal(
+              'https://join.slack.com/t/boostnote-group/shared_invite/zt-cun7pas3-WwkaezxHBB1lCbUHrwQLXw'
+            )
+          },
+        },
+        {
+          label: 'IssueHunt',
+          click: async () => {
+            await shell.openExternal(
+              'https://issuehunt.io/r/BoostIo/Boostnote.next'
+            )
+          },
+        },
+        {
+          label: 'Twitter',
+          click: async () => {
+            await shell.openExternal('https://twitter.com/boostnoteapp')
+          },
+        },
+        {
+          label: 'Facebook',
+          click: async () => {
+            await shell.openExternal(
+              'https://www.facebook.com/groups/boostnote/'
+            )
+          },
+        },
+        {
+          label: 'Reddit',
+          click: async () => {
+            await shell.openExternal('https://www.reddit.com/r/Boostnote/')
+          },
+        },
+      ] as MenuItemConstructorOptions[],
+    },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Learn More',
+          click: async () => {
+            await shell.openExternal('https://boosthub.io')
+          },
+        },
+      ] as MenuItemConstructorOptions[],
+    },
+  ]
+}

--- a/src/lib/electronOnly.ts
+++ b/src/lib/electronOnly.ts
@@ -42,6 +42,7 @@ const __ELECTRON_ONLY__: {
     channel: string,
     listener: (event: IpcRendererEvent, ...args: any[]) => void
   ): void
+  sendIpcMessage(channel: string, data: any[]): void
   removeIpcListener(
     channel: string,
     listener: (event: IpcRendererEvent, ...args: any[]) => void
@@ -80,6 +81,7 @@ const {
   openContextMenu,
   getPathByName,
   addIpcListener,
+  sendIpcMessage,
   removeIpcListener,
   removeAllIpcListeners,
   setAsDefaultProtocolClient,
@@ -137,6 +139,7 @@ export {
   openContextMenu,
   getPathByName,
   addIpcListener,
+  sendIpcMessage,
   removeIpcListener,
   removeAllIpcListeners,
   setAsDefaultProtocolClient,

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -1,0 +1,214 @@
+import { osName } from './platform'
+
+interface ModifierItem {
+  ctrl?: boolean
+  shift?: boolean
+  alt?: boolean
+}
+
+export interface KeymapItemEditableProps {
+  key: string
+  keycode: number
+  modifiers?: ModifierItem
+}
+
+export interface KeymapItem {
+  shortcutMainStroke?: KeymapItemEditableProps
+  shortcutSecondStroke?: KeymapItemEditableProps
+  description: string
+  isMenuType?: boolean
+}
+
+export const defaultKeymap = new Map<string, KeymapItem>([
+  [
+    'toggleGlobalSearch',
+    {
+      shortcutMainStroke: {
+        key: 'P',
+        keycode: 80,
+        modifiers: {
+          ctrl: true,
+        },
+      },
+      description: 'Toggles global search modal dialog',
+      isMenuType: true,
+    },
+  ],
+  [
+    'toggleLocalSearch',
+    {
+      shortcutMainStroke: {
+        key: 'F',
+        keycode: 70,
+        modifiers: {
+          ctrl: true,
+        },
+      },
+      description: 'Toggles local editor search modal dialog',
+    },
+  ],
+  [
+    'editorSaveAs',
+    {
+      shortcutMainStroke: {
+        key: 'S',
+        keycode: 83,
+        modifiers: {
+          ctrl: true,
+        },
+      },
+      description: 'Export open document (save as)',
+      isMenuType: true,
+    },
+  ],
+  [
+    'togglePreviewMode',
+    {
+      shortcutMainStroke: {
+        key: 'E',
+        keycode: 69,
+        modifiers: {
+          ctrl: true,
+        },
+      },
+      description: 'Toggles preview mode in editor',
+      isMenuType: true,
+    },
+  ],
+  [
+    'toggleSplitEditMode',
+    {
+      shortcutMainStroke: {
+        key: '\\',
+        keycode: 220,
+        modifiers: {
+          ctrl: true,
+        },
+      },
+      description: 'Toggles split edit mode in editor',
+      isMenuType: true,
+    },
+  ],
+])
+
+export function createCodemirrorTypeKeymap(
+  keymapProps: KeymapItemEditableProps
+) {
+  let keymapString = ''
+  if (keymapProps.modifiers != null) {
+    if (keymapProps.modifiers.ctrl != null) {
+      keymapString += keymapProps.modifiers.ctrl
+        ? osName == 'macos'
+          ? 'Cmd-'
+          : 'Ctrl-'
+        : ''
+    }
+    if (keymapProps.modifiers.shift != null) {
+      keymapString += keymapProps.modifiers.shift ? 'Shift-' : ''
+    }
+    if (keymapProps.modifiers.alt != null) {
+      keymapString += keymapProps.modifiers.alt ? 'Alt-' : ''
+    }
+  }
+
+  const keyLowercase = keymapProps.key.toLowerCase()
+  if (
+    keyLowercase != 'control' &&
+    keyLowercase != 'shift' &&
+    keyLowercase != 'alt'
+  ) {
+    keymapString += keymapProps.key
+  }
+  return keymapString
+}
+
+function convertNullToFalse(value?: boolean) {
+  return value == null ? false : value
+}
+
+function areShortcutsEqual(
+  first: KeymapItemEditableProps,
+  second: KeymapItemEditableProps
+) {
+  if (first.keycode != second.keycode || first.key != second.key) {
+    return false
+  }
+  if (first.modifiers && second.modifiers) {
+    if (
+      convertNullToFalse(first.modifiers.ctrl) !=
+      convertNullToFalse(second.modifiers.ctrl)
+    ) {
+      return false
+    }
+
+    if (
+      convertNullToFalse(first.modifiers.shift) !=
+      convertNullToFalse(second.modifiers.shift)
+    ) {
+      return false
+    }
+    if (
+      convertNullToFalse(first.modifiers.alt) !=
+      convertNullToFalse(second.modifiers.alt)
+    ) {
+      return false
+    }
+  } else {
+    if (
+      (first.modifiers == null && second.modifiers != null) ||
+      (first.modifiers != null && second.modifiers == null)
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function findExistingShortcut(
+  shortcutKey: string,
+  shortcut: KeymapItemEditableProps,
+  keymap: Map<string, KeymapItem>
+) {
+  for (const [key, keymapShortcut] of keymap) {
+    if (key == shortcutKey) {
+      continue
+    }
+    if (keymapShortcut.shortcutMainStroke != null) {
+      if (areShortcutsEqual(shortcut, keymapShortcut.shortcutMainStroke)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export function isMenuKeymap(keymapItem: KeymapItem): boolean {
+  return convertNullToFalse(keymapItem.isMenuType)
+}
+
+export function getGenericShortcutString(
+  shortcut: KeymapItemEditableProps
+): string {
+  return createCodemirrorTypeKeymap(shortcut)
+}
+
+export function getMenuAcceleratorForKeymapItem(
+  keymapItem: KeymapItem
+): string {
+  const keymapProps = keymapItem.shortcutMainStroke
+  if (keymapProps == null) {
+    return ''
+  }
+  let keymapString = ''
+  if (keymapProps.modifiers != null) {
+    if (keymapProps.modifiers.ctrl != null) {
+      keymapString += keymapProps.modifiers.ctrl ? 'Ctrl + ' : ''
+    }
+    if (keymapProps.modifiers.shift != null) {
+      keymapString += keymapProps.modifiers.shift ? 'Shift + ' : ''
+    }
+  }
+  keymapString += keymapProps.key
+  return keymapString
+}

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -77,7 +77,7 @@ export interface Preferences {
   'general.keymap': Map<string, KeymapItem> | null
 }
 
-function replacer(key, value: any) {
+function replacer(_key: string, value: any) {
   if (value instanceof Map && value.size > 0) {
     return {
       dataType: 'Map',
@@ -88,7 +88,7 @@ function replacer(key, value: any) {
   }
 }
 
-function reviver(key, value: any) {
+function reviver(_key: string, value: any) {
   if (typeof value === 'object' && value !== null) {
     if (value.dataType === 'Map') {
       return new Map(value.value)

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -5,6 +5,7 @@ import { useSetState } from 'react-use'
 import { useTranslation } from 'react-i18next'
 import { preferencesKey } from './localStorageKeys'
 import { NoteSortingOptions } from './sort'
+import { sendIpcMessage } from './electronOnly'
 import { nodeEnv } from '../cloud/lib/consts'
 import { setAccessToken } from '../cloud/lib/stores/electron'
 import {
@@ -295,8 +296,7 @@ function usePreferencesStore() {
       })
 
       if (isMenuKeymap(keymapItem)) {
-        const { ipcRenderer } = window.require('electron')
-        ipcRenderer.send('menuAcceleratorChanged', [
+        sendIpcMessage('menuAcceleratorChanged', [
           key,
           getMenuAcceleratorForKeymapItem(keymapItem),
         ])
@@ -328,8 +328,7 @@ function usePreferencesStore() {
       })
 
       if (isMenuKeymap(keymapItem)) {
-        const { ipcRenderer } = window.require('electron')
-        ipcRenderer.send('menuAcceleratorChanged', [key, null])
+        sendIpcMessage('menuAcceleratorChanged', [key, null])
       }
       return true
     },
@@ -339,10 +338,9 @@ function usePreferencesStore() {
   const loadKeymaps = useCallback(() => {
     const keymap = mergedPreferences['general.keymap']
     if (keymap != null) {
-      const { ipcRenderer } = window.require('electron')
       for (const [key, keymapItem] of keymap) {
         if (isMenuKeymap(keymapItem)) {
-          ipcRenderer.send('menuAcceleratorChanged', [
+          sendIpcMessage('menuAcceleratorChanged', [
             key,
             getMenuAcceleratorForKeymapItem(keymapItem),
           ])

--- a/src/locales/enUS.ts
+++ b/src/locales/enUS.ts
@@ -163,6 +163,9 @@ export default {
     'preferences.subfolders': 'Subfolders',
     'preferences.subfoldersView': 'Show content of all subfolders',
 
+    // Preferences KeymapTab
+    'preferences.keymap': 'Keymap',
+
     // Preferences EditorTab
     'preferences.editorTheme': 'Editor Theme',
     'preferences.editorFontSize': 'Editor Font Size',

--- a/static/main-preload.js
+++ b/static/main-preload.js
@@ -144,6 +144,11 @@
     ipcRenderer.on(channel, listener)
   }
 
+  function sendIpcMessage(channel, data) {
+    const { ipcRenderer } = electron
+    ipcRenderer.send(channel, data)
+  }
+
   function removeIpcListener(channel, listener) {
     const { ipcRenderer } = electron
     ipcRenderer.removeListener(channel, listener)
@@ -234,12 +239,13 @@
   window.__ELECTRON_ONLY__.openContextMenu = openContextMenu
   window.__ELECTRON_ONLY__.getPathByName = getPathByName
   window.__ELECTRON_ONLY__.addIpcListener = addIpcListener
+  window.__ELECTRON_ONLY__.sendIpcMessage = sendIpcMessage
   window.__ELECTRON_ONLY__.removeIpcListener = removeIpcListener
   window.__ELECTRON_ONLY__.removeAllIpcListeners = removeAllIpcListeners
   window.__ELECTRON_ONLY__.setAsDefaultProtocolClient = setAsDefaultProtocolClient
   window.__ELECTRON_ONLY__.removeAsDefaultProtocolClient = removeAsDefaultProtocolClient
   window.__ELECTRON_ONLY__.isDefaultProtocolClient = isDefaultProtocolClient
-  window.__ELECTRON_ONLY__.getWebContentsById
+  window.__ELECTRON_ONLY__.getWebContentsById = getWebContentsById
   window.__ELECTRON_ONLY__.setTrafficLightPosition = setTrafficLightPosition
   window.__ELECTRON_ONLY__.convertHtmlStringToPdfBuffer = convertHtmlStringToPdfBuffer
   window.__ELECTRON_ONLY__.setCookie = setCookie


### PR DESCRIPTION
**Add basic keymap handling** (#752)

- Add keymap to local lite storage
- Add search keymap to app component from preferences
- Add keymap tab in preferences
- Add keymap item section
- Add keymap assign handling
- Add basic keymap UI
- Add initial keymaps
- Add handling of multiple identical shortcuts
- Add support for dynamically changing menu items accelerators
- Add initial loading of keymaps
- Add keymap loading for menu accelerators
- Add export open document shortcut customizability

How it looks now:
![KeymapUI](https://user-images.githubusercontent.com/18196945/113772217-b36fd680-9724-11eb-90d3-7cf7061a5b77.png)

Error handling on duplicate shortcut key:
![KeymapUIError](https://user-images.githubusercontent.com/18196945/113772221-b4086d00-9724-11eb-92b8-24edc7254298.png)

Demo how it behaves:
https://user-images.githubusercontent.com/18196945/113772151-99ce8f00-9724-11eb-8057-89393119efce.mp4

Todo:
- Define all customizable keymaps
- Fix clashes with shortcuts not managed with keymaps
- Add actual keymap profiles (default profile + create profile, set profile-specific keymap, change profiles)

Test: 
In dev version
