### PR TITLE
#887 Add listener to side navigation toggle

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -334,12 +334,24 @@ const App = () => {
     },
     [storageMap, boostHubTeams, navigateToStorage, push]
   )
+  const toggleSideNavigatorHandler = useCallback(() => {
+    setPreferences((prevPreferences) => {
+      return {
+        'general.showAppNavigator': !prevPreferences[
+          'general.showAppNavigator'
+        ],
+      }
+    })
+  }, [setPreferences])
+
   useEffect(() => {
     addIpcListener('switch-workspace', switchWorkspaceHandler)
+    addIpcListener('toggle-side-navigator', toggleSideNavigatorHandler)
     return () => {
       removeIpcListener('switch-workspace', switchWorkspaceHandler)
+      removeIpcListener('toggle-side-navigator', toggleSideNavigatorHandler)
     }
-  }, [switchWorkspaceHandler])
+  }, [switchWorkspaceHandler, toggleSideNavigatorHandler])
 
   useBoostNoteProtocol()
 


### PR DESCRIPTION
As reported in issue #887 the side navigator toggle did not work via the menu bar. I found that the electron IPC listener what missing. After adding it it solve the problem.

Thanks!