### PR TITLE
Add basic plantuml, mermaid and flowchart charts (local space)

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -253,11 +253,9 @@ const MarkdownPreviewer = ({
         return <Flowchart code={children[0]} />
       },
       chart: ({ children }: any) => {
-        console.log('got to chart', children)
         return <Chart config={children[0]} />
       },
       'chart(yaml)': ({ children }: any) => {
-        console.log('got to yaml chart', children)
         return <Chart config={children[0]} isYml={true} />
       },
     },


### PR DESCRIPTION
**Add basic plantuml, mermaid and flowchart charts** (#550, #371, #678, #539)

- Add support for plantuml rendering
- Add support for charts (mermaid, flowchart)
- Add support for PDF and HTML export rendering of plantuml and mermaid

How to use it (should be the same as in cloud space, if you used it there):

Markdown to create diagrams:
[DiagramsAndCharts.txt](https://github.com/BoostIO/BoostNote.next/files/6292487/DiagramsAndCharts.txt)

## Flowchart:
![image](https://user-images.githubusercontent.com/18196945/114316211-e0e0c980-9b02-11eb-9265-e627e2a83d76.png)

## Mermaid:
![image](https://user-images.githubusercontent.com/18196945/114316221-e76f4100-9b02-11eb-959e-a846a2419c6a.png)

## Chart:
![image](https://user-images.githubusercontent.com/18196945/114316228-f1913f80-9b02-11eb-806f-4366167ca3c2.png)

## Plant UML Sequence Diagram:
![image](https://user-images.githubusercontent.com/18196945/114316312-4f258c00-9b03-11eb-8e58-064467dc6c49.png)

## Ditaa Diagrams:
![image](https://user-images.githubusercontent.com/18196945/114316262-11c0fe80-9b03-11eb-8a71-fae52c132dc8.png)

## Plant UML Activity & Class Diagrams:
![image](https://user-images.githubusercontent.com/18196945/114316366-8300b180-9b03-11eb-82cf-d7235094fd5e.png)

**Tested in** 
- Local dev
- Production AppImage (Linux)