### PR TITLE
Add support for chart PDF (and HTML) export rendering (local space)

### DIFF
--- a/src/cloud/lib/charts/charts.tsx
+++ b/src/cloud/lib/charts/charts.tsx
@@ -1,6 +1,10 @@
 import React, { useRef, useEffect, useState } from 'react'
 import _Chart from 'chart.js'
 import YAML from 'js-yaml'
+import { Node } from 'unist'
+import visit from 'unist-util-visit'
+import unified from 'unified'
+import rehypeParse from 'rehype-parse'
 
 interface ChartProps {
   config: string
@@ -36,4 +40,70 @@ export const Chart = ({ config, isYml = false }: ChartProps) => {
       <canvas ref={eleRef} />
     </div>
   )
+}
+
+interface RehypeChartProps {
+  tagName: string
+  isYml?: boolean
+}
+
+export function createAndAddElementWithId(id: string, tagName: string) {
+  let chartExportElement = window.document.getElementById(id)
+  if (chartExportElement == null) {
+    chartExportElement = window.document.createElement(tagName)
+    chartExportElement.id = id
+    chartExportElement.style.display = 'none'
+    const bodyElement = window.document.getElementsByTagName('body').item(0)
+    if (bodyElement) {
+      bodyElement.appendChild(chartExportElement)
+    }
+  }
+}
+
+// create element for export prior to exporting to be able to render them correctly
+const chartExportElementId = 'chart-export-container'
+createAndAddElementWithId(chartExportElementId, 'canvas')
+
+export function rehypeChart({ tagName, isYml = false }: RehypeChartProps) {
+  return async (tree: Node) => {
+    const eleRef = window.document.getElementById(
+      chartExportElementId
+    ) as HTMLCanvasElement
+    if (eleRef == null) {
+      return
+    }
+    const chartNodes: Node[] = []
+    visit(tree, { tagName: tagName }, (node: any) => {
+      chartNodes.push(node)
+    })
+    const parser = unified().use(rehypeParse, { fragment: true })
+    await Promise.all(
+      chartNodes.map(async (node: any) => {
+        node.tagName = 'div'
+        const value = node.children[0].value
+        try {
+          const parsed = isYml ? YAML.load(value) : JSON.parse(value)
+          const chartData = new _Chart(eleRef.getContext('2d'), parsed)
+          if (
+            parsed.maintainAspectRatio == null ||
+            parsed.maintainAspectRatio == false
+          ) {
+            let containerStyle = ''
+            if (parsed.width != null) {
+              containerStyle += `width: ${parsed.width};`
+            }
+            if (parsed.height != null) {
+              containerStyle += `height: ${parsed.height};`
+            }
+            node.properties.style = `position: relative; ${containerStyle}`
+          }
+          const img = new Image()
+          img.src = chartData.canvas.toDataURL()
+          node.children = parser.parse(img.outerHTML).children
+        } catch (err) {
+          node.children = [{ type: 'text', value: err.message }]
+        }
+      })
+    )
+  }
 }

--- a/src/cloud/lib/charts/charts.tsx
+++ b/src/cloud/lib/charts/charts.tsx
@@ -47,29 +47,27 @@ interface RehypeChartProps {
   isYml?: boolean
 }
 
-export function createAndAddElementWithId(id: string, tagName: string) {
+export function appendElementToBody(id: string, tagName: string) {
   let chartExportElement = window.document.getElementById(id)
   if (chartExportElement == null) {
     chartExportElement = window.document.createElement(tagName)
     chartExportElement.id = id
     chartExportElement.style.display = 'none'
-    const bodyElement = window.document.getElementsByTagName('body').item(0)
-    if (bodyElement) {
-      bodyElement.appendChild(chartExportElement)
-    }
+    const bodyElement = window.document.body
+    bodyElement.appendChild(chartExportElement)
   }
 }
 
 // create element for export prior to exporting to be able to render them correctly
 const chartExportElementId = 'chart-export-container'
-createAndAddElementWithId(chartExportElementId, 'canvas')
+appendElementToBody(chartExportElementId, 'canvas')
 
 export function rehypeChart({ tagName, isYml = false }: RehypeChartProps) {
   return async (tree: Node) => {
-    const eleRef = window.document.getElementById(
+    const chartCanvasElement = window.document.getElementById(
       chartExportElementId
     ) as HTMLCanvasElement
-    if (eleRef == null) {
+    if (chartCanvasElement == null) {
       return
     }
     const chartNodes: Node[] = []
@@ -83,7 +81,10 @@ export function rehypeChart({ tagName, isYml = false }: RehypeChartProps) {
         const value = node.children[0].value
         try {
           const parsed = isYml ? YAML.load(value) : JSON.parse(value)
-          const chartData = new _Chart(eleRef.getContext('2d'), parsed)
+          const chartData = new _Chart(
+            chartCanvasElement.getContext('2d'),
+            parsed
+          )
           if (
             parsed.maintainAspectRatio == null ||
             parsed.maintainAspectRatio == false

--- a/src/cloud/lib/charts/flowchart.tsx
+++ b/src/cloud/lib/charts/flowchart.tsx
@@ -4,7 +4,7 @@ import { Node } from 'unist'
 import visit from 'unist-util-visit'
 import unified from 'unified'
 import rehypeParse from 'rehype-parse'
-import { createAndAddElementWithId } from './charts'
+import { appendElementToBody } from './charts'
 
 export interface FlowchartProps {
   code: string
@@ -48,7 +48,7 @@ export const Flowchart = ({ code, options }: FlowchartProps) => {
 
 // create element for export prior to exporting to be able to render them correctly
 const flowChartExportElementId = 'flowchart-export-container'
-createAndAddElementWithId(flowChartExportElementId, 'div')
+appendElementToBody(flowChartExportElementId, 'div')
 
 export function rehypeFlowChart() {
   return async (tree: Node) => {
@@ -56,8 +56,10 @@ export function rehypeFlowChart() {
     visit(tree, { tagName: 'flowchart' }, (node: any) => {
       flowchartNodes.push(node)
     })
-    const eleRef = window.document.getElementById(flowChartExportElementId)
-    if (eleRef == null) {
+    const flowChartElement = window.document.getElementById(
+      flowChartExportElementId
+    )
+    if (flowChartElement == null) {
       return
     }
     const parser = unified().use(rehypeParse, { fragment: true })
@@ -66,14 +68,14 @@ export function rehypeFlowChart() {
         const value = node.children[0].value
         try {
           const diagram = FlowChart.parse(value)
-          while (eleRef.firstChild != null) {
-            eleRef.removeChild(eleRef.lastChild!)
+          while (flowChartElement.firstChild != null) {
+            flowChartElement.removeChild(flowChartElement.lastChild!)
           }
 
-          diagram.drawSVG(eleRef, { maxWidth: 3 })
-          const svg = eleRef.childNodes[0] as SVGElement
+          diagram.drawSVG(flowChartElement, { maxWidth: 3 })
+          const svg = flowChartElement.childNodes[0] as SVGElement
           if (svg != null && typeof svg.getAttribute('height') === 'string') {
-            eleRef.style.setProperty(
+            flowChartElement.style.setProperty(
               'height',
               `${svg.getAttribute('height')!}px`
             )

--- a/src/cloud/lib/charts/flowchart.tsx
+++ b/src/cloud/lib/charts/flowchart.tsx
@@ -1,5 +1,10 @@
 import React, { useRef, useEffect, useState } from 'react'
 import FlowChart from 'flowchart.js'
+import { Node } from 'unist'
+import visit from 'unist-util-visit'
+import unified from 'unified'
+import rehypeParse from 'rehype-parse'
+import { createAndAddElementWithId } from './charts'
 
 export interface FlowchartProps {
   code: string
@@ -39,4 +44,47 @@ export const Flowchart = ({ code, options }: FlowchartProps) => {
   }
 
   return <div ref={eleRef} />
+}
+
+// create element for export prior to exporting to be able to render them correctly
+const flowChartExportElementId = 'flowchart-export-container'
+createAndAddElementWithId(flowChartExportElementId, 'div')
+
+export function rehypeFlowChart() {
+  return async (tree: Node) => {
+    const flowchartNodes: Node[] = []
+    visit(tree, { tagName: 'flowchart' }, (node: any) => {
+      flowchartNodes.push(node)
+    })
+    const eleRef = window.document.getElementById(flowChartExportElementId)
+    if (eleRef == null) {
+      return
+    }
+    const parser = unified().use(rehypeParse, { fragment: true })
+    await Promise.all(
+      flowchartNodes.map(async (node: any) => {
+        const value = node.children[0].value
+        try {
+          const diagram = FlowChart.parse(value)
+          while (eleRef.firstChild != null) {
+            eleRef.removeChild(eleRef.lastChild!)
+          }
+
+          diagram.drawSVG(eleRef, { maxWidth: 3 })
+          const svg = eleRef.childNodes[0] as SVGElement
+          if (svg != null && typeof svg.getAttribute('height') === 'string') {
+            eleRef.style.setProperty(
+              'height',
+              `${svg.getAttribute('height')!}px`
+            )
+            node.properties.style = `height: ${svg.getAttribute('height')!}px`
+            node.properties.className = ''
+          }
+          node.children = parser.parse(svg.outerHTML).children
+        } catch (err) {
+          node.children = [{ type: 'text', value: err.message }]
+        }
+      })
+    )
+  }
 }


### PR DESCRIPTION
**Add support for chart PDF export rendering**

- Add support for Charts and FlowChart export in PDF and HTML

Markdown, PDFs, HTMLs files for testing export:
[ChartExports.zip](https://github.com/BoostIO/BoostNote.next/files/6329873/ChartExports.zip)

Preview of export:
![image](https://user-images.githubusercontent.com/18196945/115124246-82fc2800-9fc1-11eb-8686-4d6107d463c6.png)
![image](https://user-images.githubusercontent.com/18196945/115124267-99a27f00-9fc1-11eb-8d9b-8c8b64ce66f4.png)

**Tested in** 
- Local dev
- Production AppImage (Linux)