### PR TITLE
UI: Removed Border Radius from Context Menu on Top Bar

### DIFF
--- a/src/shared/components/organisms/Topbar/atoms/TopbarActionItem.tsx
+++ b/src/shared/components/organisms/Topbar/atoms/TopbarActionItem.tsx
@@ -98,7 +98,6 @@ const Container = styled.button<{ depth: number }>`
     }
   }
 
-  border-radius: ${({ theme }) => theme.borders.radius}px;
   &:hover {
     background-color: ${({ theme }) => theme.colors.background.tertiary};
   }

--- a/src/shared/components/organisms/Topbar/atoms/TopbarTreeItem.tsx
+++ b/src/shared/components/organisms/Topbar/atoms/TopbarTreeItem.tsx
@@ -100,6 +100,10 @@ const Container = styled.div<{ depth: number }>`
   white-space: nowrap;
   font-size: ${({ theme }) => theme.sizes.fonts.df}px;
 
+  &.topbar__tree__item {
+    border-radius: 0;
+  }
+
   .topbar__tree__item__wrapper {
     width: 100%;
     flex: 1 1 auto;

--- a/src/shared/components/organisms/Topbar/atoms/TopbarTreeItem.tsx
+++ b/src/shared/components/organisms/Topbar/atoms/TopbarTreeItem.tsx
@@ -100,10 +100,6 @@ const Container = styled.div<{ depth: number }>`
   white-space: nowrap;
   font-size: ${({ theme }) => theme.sizes.fonts.df}px;
 
-  &.topbar__tree__item {
-    border-radius: 0;
-  }
-
   .topbar__tree__item__wrapper {
     width: 100%;
     flex: 1 1 auto;
@@ -142,7 +138,6 @@ const Container = styled.div<{ depth: number }>`
     padding-right: 0 !important;
   }
 
-  border-radius: ${({ theme }) => theme.borders.radius}px;
   &:hover {
     background-color: ${({ theme }) => theme.colors.background.tertiary};
   }

--- a/src/shared/components/organisms/Topbar/molecules/TopbarNavigationContext.tsx
+++ b/src/shared/components/organisms/Topbar/molecules/TopbarNavigationContext.tsx
@@ -140,10 +140,6 @@ const Container = styled.div`
     overflow: auto;
   }
 
-  .topbar__action__item {
-    border-radius: 0;
-  }
-
   .topbar__action__item + .topbar__tree__navigation {
     border-top: 1px solid ${({ theme }) => theme.colors.border.main};
     margin-top: ${({ theme }) => theme.sizes.spaces.xsm}px;

--- a/src/shared/components/organisms/Topbar/molecules/TopbarNavigationContext.tsx
+++ b/src/shared/components/organisms/Topbar/molecules/TopbarNavigationContext.tsx
@@ -140,6 +140,10 @@ const Container = styled.div`
     overflow: auto;
   }
 
+  .topbar__action__item {
+    border-radius: 0;
+  }
+
   .topbar__action__item + .topbar__tree__navigation {
     border-top: 1px solid ${({ theme }) => theme.colors.border.main};
     margin-top: ${({ theme }) => theme.sizes.spaces.xsm}px;


### PR DESCRIPTION
I removed `border-radius` from the context menu items on the top bar.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-05-01 at 16 14 36](https://user-images.githubusercontent.com/2410692/116775026-6967df80-aa9b-11eb-894c-fae0770a84f9.png) | ![CleanShot 2021-05-01 at 16 33 03](https://user-images.githubusercontent.com/2410692/116775034-72f14780-aa9b-11eb-83e5-7e0812e6080c.png) |