### PR TITLE
fix status check bug causing closed to always be set outdated

### DIFF
--- a/src/cloud/components/molecules/Editor/index.tsx
+++ b/src/cloud/components/molecules/Editor/index.tsx
@@ -274,17 +274,18 @@ const Editor = ({
         if (
           absoluteAnchor != null &&
           absoluteHead != null &&
-          absoluteAnchor.index !== absoluteHead.index &&
-          thread.status.type === 'open'
+          absoluteAnchor.index !== absoluteHead.index
         ) {
-          comments.push({
-            id: thread.id,
-            start: absoluteAnchor.index,
-            end: absoluteHead.index,
-            active:
-              commentState.mode === 'thread' &&
-              thread.id === commentState.thread.id,
-          })
+          if (thread.status.type === 'open') {
+            comments.push({
+              id: thread.id,
+              start: absoluteAnchor.index,
+              end: absoluteHead.index,
+              active:
+                commentState.mode === 'thread' &&
+                thread.id === commentState.thread.id,
+            })
+          }
         } else if (connState === 'synced') {
           commentActions.threadOutdated(thread)
         }


### PR DESCRIPTION
Status check in out `if` causing closed comment threads to always be set outdated.