### PR TITLE
UI: Added `line-height` to `.CodeMirror`

### DIFF
--- a/src/cloud/components/molecules/Editor/index.tsx
+++ b/src/cloud/components/molecules/Editor/index.tsx
@@ -1234,6 +1234,7 @@ const StyledEditor = styled.div`
     height: 100%;
     position: relative;
     z-index: 0 !important;
+    line-height: 1.4em;
     .CodeMirror-hints {
       position: absolute;
       z-index: 10;


### PR DESCRIPTION
I added `line-height: 1.4em` to `.CodeMirror` to make all lines have the same height in the editor.