### PR TITLE
UI: Restyled Timeline Page

### DIFF
--- a/src/cloud/components/molecules/Timeline/TimelineList.tsx
+++ b/src/cloud/components/molecules/Timeline/TimelineList.tsx
@@ -9,6 +9,7 @@ import styled from '../../../lib/styled'
 import { getHexFromUUID } from '../../../lib/utils/string'
 import TimelineListItem from './TimelineListItem'
 import { TimelineUser } from '../../../pages/[teamId]/timeline'
+import { SerializedWorkspace } from '../../../interfaces/db/workspace'
 
 export interface TimelineListProps {
   heading: string
@@ -16,6 +17,7 @@ export interface TimelineListProps {
   events: SerializedAppEvent[]
   timeFormat?: (date: Date) => string
   usersMap: Map<string, TimelineUser>
+  workspacesMap: Map<string, SerializedWorkspace>
 }
 
 const TimelineList = ({
@@ -23,6 +25,7 @@ const TimelineList = ({
   team,
   events,
   usersMap,
+  workspacesMap,
 }: TimelineListProps) => {
   const { docsMap } = useNav()
   const listRef = React.createRef<HTMLDivElement>()
@@ -73,6 +76,10 @@ const TimelineList = ({
                 []
               )
 
+              const path = `/${
+                workspacesMap.get(timelineDoc.doc.workspaceId)?.name
+              }${timelineDoc.doc.folderPathname}`
+
               return (
                 <TimelineListItem
                   item={timelineDoc.doc}
@@ -80,6 +87,7 @@ const TimelineList = ({
                   team={team}
                   id={childId}
                   editors={editors}
+                  path={path}
                 />
               )
             })}
@@ -151,7 +159,7 @@ const StyledTimelineListContent = styled.div`
   .sideNavWrapper {
     width: 100%;
     flex: inherit;
-    padding: 0 ${({ theme }) => theme.space.xxsmall}px;
+    padding: 0 ${({ theme }) => theme.space.xlarge}px;
     z-index: initial !important;
   }
 
@@ -160,7 +168,7 @@ const StyledTimelineListContent = styled.div`
   }
 
   .itemLink {
-    padding: 0 ${({ theme }) => theme.space.xsmall}px;
+    padding-right: ${({ theme }) => theme.space.xsmall}px;
 
     > div {
       font-size: ${({ theme }) => theme.fontSizes.default}px;

--- a/src/cloud/components/molecules/Timeline/TimelineListItem.tsx
+++ b/src/cloud/components/molecules/Timeline/TimelineListItem.tsx
@@ -110,7 +110,7 @@ const TimelineListItem = ({
             id={id}
           >
             <SideNavLabelStyle>
-              <PathLabel>{path}</PathLabel>
+              {path !== null && <PathLabel>{path}</PathLabel>}
               <span>{getDocTitle(item, 'Untitled')}</span>
             </SideNavLabelStyle>
             {item.tags != null && item.tags.length > 0 && (

--- a/src/cloud/components/molecules/Timeline/TimelineListItem.tsx
+++ b/src/cloud/components/molecules/Timeline/TimelineListItem.tsx
@@ -10,7 +10,7 @@ import {
   StyledNavTagsList,
 } from '../../organisms/Sidebar/SideNavigator/styled'
 import cc from 'classcat'
-import { mdiCardTextOutline } from '@mdi/js'
+import { mdiFileDocumentOutline } from '@mdi/js'
 import { getDocTitle } from '../../../lib/utils/patterns'
 import { getFormattedBoosthubDate } from '../../../lib/date'
 import SideNavIcon from '../../organisms/Sidebar/SideNavigator/SideNavIcon'
@@ -26,6 +26,7 @@ interface TimelineListItemProps {
   team: SerializedTeam
   id: string
   editors: TimelineUser[]
+  path?: string
 }
 
 const TimelineListItem = ({
@@ -34,6 +35,7 @@ const TimelineListItem = ({
   team,
   id,
   editors,
+  path,
 }: TimelineListItemProps) => {
   const [focused, setFocused] = useState(false)
 
@@ -95,7 +97,7 @@ const TimelineListItem = ({
       <div className={cc(['sideNavWrapper'])}>
         <SideNavClickableButtonStyle>
           <SideNavIcon
-            mdiPath={mdiCardTextOutline}
+            mdiPath={mdiFileDocumentOutline}
             item={item}
             type='doc'
             className='marginLeft'
@@ -108,7 +110,8 @@ const TimelineListItem = ({
             id={id}
           >
             <SideNavLabelStyle>
-              {getDocTitle(item, 'Untitled')}
+              <PathLabel>{path}</PathLabel>
+              <span>{getDocTitle(item, 'Untitled')}</span>
             </SideNavLabelStyle>
             {item.tags != null && item.tags.length > 0 && (
               <StyledNavTagsList>
@@ -155,6 +158,13 @@ const StyledUsersListItem = styled.div`
   ${userIconStyle}
   width: 24px;
   height: 24px;
+`
+
+const PathLabel = styled.span`
+  display: block;
+  color: ${({ theme }) => theme.subtleTextColor};
+  font-size: ${({ theme }) => theme.fontSizes.default}px;
+  margin-bottom: ${({ theme }) => theme.space.xxsmall}px;
 `
 
 export default TimelineListItem

--- a/src/cloud/components/organisms/Sidebar/SideNavigator/styled.ts
+++ b/src/cloud/components/organisms/Sidebar/SideNavigator/styled.ts
@@ -201,6 +201,10 @@ export const SideNavClickableButtonStyle = styled.div`
 `
 
 export const SideNavLabelStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  justify-content: center;
   min-width: 30px;
   overflow: hidden;
   white-space: nowrap !important;
@@ -211,6 +215,7 @@ export const SideNavLabelStyle = styled.div`
   text-align: left;
   text-overflow: ellipsis;
   font-size: ${({ theme }) => theme.fontSizes.small}px;
+  line-height: normal;
 `
 
 export const StyledNavTagsList = styled.div`
@@ -267,6 +272,7 @@ export const SideNavIconStyle = styled.div`
 
   &.emoji-icon {
     flex-shrink: 0;
+    color: #329bbe;
   }
 
   &:hover {

--- a/src/cloud/pages/[teamId]/timeline.tsx
+++ b/src/cloud/pages/[teamId]/timeline.tsx
@@ -21,6 +21,7 @@ import { GetInitialPropsParameters } from '../../interfaces/pages'
 import { useRouter } from '../../lib/router'
 import EmojiIcon from '../../components/atoms/EmojiIcon'
 import { topParentId } from '../../lib/mappers/topbarTree'
+import { useNav } from '../../lib/stores/nav'
 
 export interface TimelineUser {
   user: SerializedUser
@@ -31,6 +32,7 @@ export interface TimelineUser {
 const TimelinePage = ({ team, events }: TimelinePageData) => {
   const { push } = useRouter()
   const { permissions = [] } = usePage()
+  const { workspacesMap } = useNav()
 
   const { today, thisWeek, others } = useMemo(() => {
     const todayDate = new Date()
@@ -117,7 +119,6 @@ const TimelinePage = ({ team, events }: TimelinePageData) => {
       <LazyDefaultLayout>
         <Application
           content={{
-            reduced: true,
             topbar: {
               breadcrumbs: [
                 {
@@ -132,16 +133,6 @@ const TimelinePage = ({ team, events }: TimelinePageData) => {
                 },
               ],
             },
-            header: (
-              <>
-                <EmojiIcon
-                  defaultIcon={mdiClockOutline}
-                  style={{ marginRight: 10 }}
-                  size={16}
-                />
-                <span style={{ marginRight: 10 }}>Timeline</span>
-              </>
-            ),
           }}
         >
           <StyledTimelinePage>
@@ -152,6 +143,7 @@ const TimelinePage = ({ team, events }: TimelinePageData) => {
                 events={today}
                 usersMap={usersMap}
                 timeFormat={dateFormatDistanceToNow}
+                workspacesMap={workspacesMap}
               />
             ) : (
               <>
@@ -164,6 +156,7 @@ const TimelinePage = ({ team, events }: TimelinePageData) => {
               team={team}
               events={thisWeek}
               usersMap={usersMap}
+              workspacesMap={workspacesMap}
             />
 
             <TimelineList
@@ -171,6 +164,7 @@ const TimelinePage = ({ team, events }: TimelinePageData) => {
               team={team}
               events={others}
               usersMap={usersMap}
+              workspacesMap={workspacesMap}
             />
             {events.length !== 10 && events.length % 10 === 0 && (
               <div className='more-button'>
@@ -217,8 +211,9 @@ const StyledTimelinePage = styled.div`
   h2 {
     color: ${({ theme }) => theme.subtleTextColor};
     font-size: ${({ theme }) => theme.fontSizes.default}px;
-    padding: ${({ theme }) => theme.space.xsmall}px 0;
-    margin-top: ${({ theme }) => theme.space.large}px;
+    padding: ${({ theme }) => theme.space.xsmall}px
+      ${({ theme }) => theme.space.xlarge}px;
+    margin-top: ${({ theme }) => theme.space.medium}px;
     margin-bottom: 0;
     border-bottom: 1px solid ${({ theme }) => theme.subtleBorderColor};
   }


### PR DESCRIPTION
- Removed header
- Expanded border to the edge of the section
- Put the same icon with sidenav
- Show breadcrumb above the doc title

| Before  | After |
| ------------- | ------------- |
| <img width="1348" alt="Screen Shot 2021-06-21 at 1 31 01 PM" src="https://user-images.githubusercontent.com/2410692/122760970-aa7bb380-d2d6-11eb-8835-e7030d9d96bf.png"> | ![CleanShot 2021-06-21 at 21 15 40](https://user-images.githubusercontent.com/2410692/122761012-b8c9cf80-d2d6-11eb-9f20-cdd4e66fad8b.png) |