### PR TITLE
Add untitled as initial value in doc and folder creation input

### DIFF
--- a/src/shared/components/organisms/Sidebar/atoms/SidebarTreeForm.tsx
+++ b/src/shared/components/organisms/Sidebar/atoms/SidebarTreeForm.tsx
@@ -19,12 +19,13 @@ const SidebarTreeForm = ({
   createCallback,
 }: SideNavigatorFolderFormProps) => {
   const [sending, setSending] = useState<boolean>(false)
-  const [name, setName] = useState<string>('')
+  const [name, setName] = useState<string>('Untitled')
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffectOnce(() => {
     if (inputRef.current != null) {
       inputRef.current.focus()
+      inputRef.current.setSelectionRange(0, name.length)
     }
   })
 


### PR DESCRIPTION
Add untitled as initial value in doc and folder creation input
Select whole range when initially input is opened

The feature is added to both local and cloud spaces.

Tested in cloud and local space:
Desktop app dev
Webapp dev