### PR TITLE
Add shortcuts to keymap for inserting date strings

### DIFF
--- a/src/components/atoms/CodeEditor.tsx
+++ b/src/components/atoms/CodeEditor.tsx
@@ -94,6 +94,8 @@ class CodeEditor extends React.Component<CodeEditorProps> {
   codeMirror?: CodeMirror.EditorFromTextArea
   prevLocalSearchShortcut?: string
   prevLocalReplaceShortcut?: string
+  prevInsertLocaleDateShortcut?: string
+  prevInsertDateAndTimeShortcut?: string
 
   componentDidMount() {
     const indentSize = this.props.indentSize == null ? 2 : this.props.indentSize
@@ -172,10 +174,16 @@ class CodeEditor extends React.Component<CodeEditorProps> {
       localSearchShortcut,
       localReplaceShortcut,
     ] = this.getCurrentSearchKeymaps()
+    const [
+      insertLocaleDateShortcut,
+      insertDateAndTimeShortcut,
+    ] = this.getCurrentDateKeymaps()
     if (
       this.props.keyMap !== prevProps.keyMap ||
       this.prevLocalSearchShortcut != localSearchShortcut ||
-      this.prevLocalReplaceShortcut != localReplaceShortcut
+      this.prevLocalReplaceShortcut != localReplaceShortcut ||
+      this.prevInsertLocaleDateShortcut != insertLocaleDateShortcut ||
+      this.prevInsertDateAndTimeShortcut != insertDateAndTimeShortcut
     ) {
       this.codeMirror.setOption('extraKeys', this.getExtraKeys(keyMap))
     }
@@ -203,6 +211,24 @@ class CodeEditor extends React.Component<CodeEditorProps> {
     return [localSearchShortcut, localReplaceShortcut]
   }
 
+  getCurrentDateKeymaps(): string[] {
+    let insertLocaleDateShortcut = this.props.getCustomKeymap(
+      'insertLocaleDateString'
+    )
+    let insertDateAndTimeShortcut = this.props.getCustomKeymap(
+      'insertDateAndTimeString'
+    )
+    if (insertLocaleDateShortcut == null) {
+      insertLocaleDateShortcut =
+        osName === 'macos' ? 'Shift-Cmd-/' : 'Shift-Ctrl-/'
+    }
+    if (insertDateAndTimeShortcut == null) {
+      insertDateAndTimeShortcut =
+        osName === 'macos' ? 'Cmd-Alt-/' : 'Ctrl-Alt-/'
+    }
+    return [insertLocaleDateShortcut, insertDateAndTimeShortcut]
+  }
+
   getExtraKeys = (keyMapStyle: string) => {
     const [
       localSearchShortcut,
@@ -222,13 +248,33 @@ class CodeEditor extends React.Component<CodeEditorProps> {
     }
     extraKeys[localSearchShortcut] = (cm: CodeMirror.Editor) =>
       this.handleOnLocalSearchToggle(cm, true)
-
     extraKeys[localReplaceShortcut] = (cm: CodeMirror.Editor) =>
       this.handleOnLocalSearchReplaceToggle(cm, true)
 
+    const [
+      insertLocaleDateShortcut,
+      insertDateAndTimeShortcut,
+    ] = this.getCurrentDateKeymaps()
+    extraKeys[insertLocaleDateShortcut] = (cm: CodeMirror.Editor) =>
+      this.handleInsertLocaleDateString(cm)
+    extraKeys[insertDateAndTimeShortcut] = (cm: CodeMirror.Editor) =>
+      this.handleInsertLocaleString(cm)
+
     this.prevLocalSearchShortcut = localSearchShortcut
     this.prevLocalReplaceShortcut = localReplaceShortcut
+    this.prevInsertLocaleDateShortcut = insertLocaleDateShortcut
+    this.prevInsertDateAndTimeShortcut = insertDateAndTimeShortcut
     return extraKeys
+  }
+
+  handleInsertLocaleDateString = (editor: CodeMirror.Editor) => {
+    const dateNow = new Date()
+    editor.replaceSelection(dateNow.toLocaleDateString())
+  }
+
+  handleInsertLocaleString = (editor: CodeMirror.Editor) => {
+    const dateNow = new Date()
+    editor.replaceSelection(dateNow.toLocaleString())
   }
 
   handleOnLocalSearchReplaceToggle = (

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -122,6 +122,42 @@ export const defaultKeymap = new Map<string, KeymapItem>([
       isMenuType: true,
     },
   ],
+  [
+    'insertLocaleDateString',
+    {
+      shortcutMainStroke: {
+        key: '/',
+        keycode: 191,
+        modifiers:
+          osName === 'macos'
+            ? { meta: true, shift: true }
+            : {
+                ctrl: true,
+                shift: true,
+              },
+      },
+      description: 'Inserts locale date',
+      isMenuType: false,
+    },
+  ],
+  [
+    'insertDateAndTimeString',
+    {
+      shortcutMainStroke: {
+        key: '/',
+        keycode: 191,
+        modifiers:
+          osName === 'macos'
+            ? { meta: true, alt: true }
+            : {
+                ctrl: true,
+                alt: true,
+              },
+      },
+      description: 'Inserts date and time',
+      isMenuType: false,
+    },
+  ],
 ])
 
 export function compareEventKeyWithKeymap(
@@ -149,17 +185,17 @@ export function createCodemirrorTypeKeymap(
 ) {
   let keymapString = ''
   if (keymapProps.modifiers != null) {
-    if (keymapProps.modifiers.ctrl != null) {
-      keymapString += keymapProps.modifiers.ctrl ? 'Ctrl-' : ''
-    }
     if (keymapProps.modifiers.shift != null) {
       keymapString += keymapProps.modifiers.shift ? 'Shift-' : ''
     }
-    if (keymapProps.modifiers.alt != null) {
-      keymapString += keymapProps.modifiers.alt ? 'Alt-' : ''
-    }
     if (keymapProps.modifiers.meta != null) {
       keymapString += keymapProps.modifiers.meta ? 'Cmd-' : ''
+    }
+    if (keymapProps.modifiers.ctrl != null) {
+      keymapString += keymapProps.modifiers.ctrl ? 'Ctrl-' : ''
+    }
+    if (keymapProps.modifiers.alt != null) {
+      keymapString += keymapProps.modifiers.alt ? 'Alt-' : ''
     }
   }
 


### PR DESCRIPTION
Add shortcuts to keymap for inserting date strings

- Also fix codemirror order in which shortcut is generated
  - must be Shift->Ctrl/Cmd/->Alt->Key
  
Default shortcuts are:
`Shift+Ctrl+/` or `Shift+Cmd+/` for `macOS` - Inserts locale date (for example: `6/22/2021`)
`Ctrl+Alt+/` or `Shift+Alt+/` for `macOS` - Inserts date and time (for example: `6/22/2021, 6:47:46 PM`) 
  
Tested in local development mode and AppImage:
 - Change keymaps to something different, test with default shortcuts
 - Add locale date inside editor
 - Add date and time inside editor