### PR TITLE
UI: Restyled Changing Plan Popup

### DIFF
--- a/src/cloud/components/organisms/Subscription/SubscriptionManagement.tsx
+++ b/src/cloud/components/organisms/Subscription/SubscriptionManagement.tsx
@@ -460,6 +460,8 @@ const StyledPopup = styled.div`
     background-color: ${({ theme }) => theme.baseBackgroundColor};
     box-shadow: ${({ theme }) => theme.baseShadowColor};
     border-radius: 4px;
+    font-size: ${({ theme }) => theme.fontSizes.medium}px;
+    line-height: 1.6;
     overflow: auto;
 
     .btn {
@@ -473,6 +475,10 @@ const StyledPopup = styled.div`
     .spinner {
       border-color: ${({ theme }) => theme.whiteBorderColor};
       border-right-color: transparent;
+    }
+
+    h3 {
+      font-size: ${({ theme }) => theme.fontSizes.large}px;
     }
 
     a {
@@ -497,6 +503,8 @@ const StyledPopup = styled.div`
 
   .popup__billing {
     width: 100%;
+    margin-top: ${({ theme }) => theme.space.small}px;
+    margin-bottom: ${({ theme }) => theme.space.large}px;
   }
 `
 


### PR DESCRIPTION
I adjusted `font-size` and `margin` of the downgrade and upgrade plan popups.

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2021-06-26 at 12 40 01](https://user-images.githubusercontent.com/2410692/123501022-27af7b80-d67d-11eb-9565-6f634186e024.png) | ![CleanShot 2021-06-26 at 12 42 05](https://user-images.githubusercontent.com/2410692/123501030-37c75b00-d67d-11eb-9995-18452da30f7d.png) |
| ![CleanShot 2021-06-26 at 12 40 20](https://user-images.githubusercontent.com/2410692/123501039-4150c300-d67d-11eb-8e60-4b9fa109bd4f.png) | ![CleanShot 2021-06-26 at 12 46 05](https://user-images.githubusercontent.com/2410692/123501047-4ca3ee80-d67d-11eb-9887-70ce8e394bcc.png) |