### PR TITLE
UI: Removed Team Member Limit Alert

### DIFF
--- a/src/cloud/components/molecules/Banner/SubLimitReachedBanner.tsx
+++ b/src/cloud/components/molecules/Banner/SubLimitReachedBanner.tsx
@@ -28,9 +28,8 @@ const DocLimitReachedBanner = () => {
     <Container className='doc__edit__limit'>
       <Banner variant='warning' className='doc__edit__limit'>
         <span className='limit__reached__banner__label'>
-          {subscription == null
-            ? `Your space exceeds the limit of your current plan. (${freePlanDocLimit} created documents)`
-            : `Your space exceeds the limit of your current plan. (${subscription.seats} team members)`}
+          {subscription == null &&
+            `Your space exceeds the limit of your current plan. (${freePlanDocLimit} created documents)`}
         </span>
         <Button
           variant='primary'


### PR DESCRIPTION
Since there is no limitation for team member count, so I removed the alert for that.

<img width="1098" alt="Screen Shot 2021-06-08 at 2 26 13 PM" src="https://user-images.githubusercontent.com/2410692/123501101-837a0480-d67d-11eb-867e-6c452fa677a9.png">
