### PR TITLE
Fix active input element condition

### DIFF
--- a/src/shared/lib/dom.ts
+++ b/src/shared/lib/dom.ts
@@ -15,11 +15,10 @@ export const isActiveElementAnInput = () => {
   const activeElement = document.activeElement
   const inputs = ['input', 'select', 'textarea']
 
-  console.log(document.activeElement)
   if (
     activeElement != null &&
-    (activeElement as HTMLElement).isContentEditable &&
-    inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1
+    ((activeElement as HTMLElement).isContentEditable ||
+      inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1)
   ) {
     return true
   }


### PR DESCRIPTION
Fix active input element condition

Without this, the active input element is not recognized and so shortcuts like `Ctrl+Shift+ArrowLeft` does jump out of editor instead of selecting the word

See this issue: #1027 