### PR TITLE
Add initial toc component and handling in preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80937,6 +80937,27 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
     },
+    "mdast-util-toc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.1.0.tgz",
+      "integrity": "sha512-csimbRIVkiqc+PpFeKDGQ/Ck2N4f9FYH3zzBMMJzcxoKL8m+cM0n94xXm0I9eaxHnKdY9n145SGTdyJC7i273g==",
+      "requires": {
+        "@types/mdast": "^3.0.3",
+        "@types/unist": "^2.0.3",
+        "extend": "^3.0.2",
+        "github-slugger": "^1.2.1",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        }
+      }
+    },
     "mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -85423,6 +85444,15 @@
         "stringify-entities": "^3.0.0",
         "unherit": "^1.0.4",
         "xtend": "^4.0.1"
+      }
+    },
+    "remark-toc": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-7.2.0.tgz",
+      "integrity": "sha512-ppHepvpbg7j5kPFmU5rzDC4k2GTcPDvWcxXyr/7BZzO1cBSPk0stKtEJdsgAyw2WHKPGxadcHIZRjb2/sHxjkg==",
+      "requires": {
+        "@types/unist": "^2.0.3",
+        "mdast-util-toc": "^5.0.0"
       }
     },
     "remove-trailing-separator": {

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
     "remark-shortcodes": "^0.3.1",
     "remark-slug": "^6.0.0",
     "remark-stringify": "^8.1.1",
+    "remark-toc": "^7.2.0",
     "rxjs": "^6.6.3",
     "semver": "^7.3.4",
     "shortid": "^2.2.15",

--- a/src/cloud/components/atoms/MarkdownView/index.tsx
+++ b/src/cloud/components/atoms/MarkdownView/index.tsx
@@ -44,6 +44,7 @@ import Icon from '../../../../shared/components/atoms/Icon'
 import styled from '../../../../shared/lib/styled'
 import throttle from 'lodash.throttle'
 import CodeFence from '../../../../shared/components/atoms/markdown/CodeFence'
+import { TableOfContents } from '../../molecules/TableOfContents'
 
 const remarkAdmonitionOptions = {
   tag: ':::',
@@ -51,7 +52,7 @@ const remarkAdmonitionOptions = {
   infima: false,
 }
 
-const schema = mergeDeepRight(gh, {
+export const schema = mergeDeepRight(gh, {
   attributes: {
     '*': [
       ...gh.attributes['*'],
@@ -196,6 +197,9 @@ const MarkdownView = ({
         shortcode:
           shortcodeHandler == null
             ? ({ identifier, entityId }: any) => {
+                if (identifier === 'toc') {
+                  return <TableOfContents content={content}></TableOfContents>
+                }
                 return (
                   <Shortcode
                     entity={identifier}
@@ -263,6 +267,7 @@ const MarkdownView = ({
 
     return parser
   }, [
+    content,
     settings,
     updateContent,
     shortcodeHandler,

--- a/src/cloud/components/molecules/Editor/index.tsx
+++ b/src/cloud/components/molecules/Editor/index.tsx
@@ -67,6 +67,7 @@ import {
   focusEditorEventEmitter,
   toggleSplitEditModeEventEmitter,
   togglePreviewModeEventEmitter,
+  focusEditorHeadingEventEmitter,
 } from '../../../lib/utils/events'
 import { ScrollSync, scrollSyncer } from '../../../lib/editor/scrollSync'
 import CodeMirrorEditor from '../../../lib/editor/components/CodeMirrorEditor'
@@ -724,6 +725,36 @@ const Editor = ({
     editorRef.current.focus()
   }, [editorLayout])
 
+  const focusEditorHeading = useCallback(
+    (event: CustomEvent<{ heading: string }>) => {
+      if (editorLayout === 'preview') {
+        return
+      }
+
+      if (editorRef.current == null) {
+        return
+      }
+
+      const heading = event.detail.heading
+      const targetHeadingElement = document.getElementById(
+        `user-content-${heading}`
+      )
+      if (targetHeadingElement == null) {
+        return
+      }
+      const dataLineAttribute = targetHeadingElement.attributes.getNamedItem(
+        'data-line'
+      )
+      if (dataLineAttribute == null) {
+        return
+      }
+      const focusLine: number = parseInt(dataLineAttribute.value)
+      editorRef.current.focus()
+      editorRef.current.setCursor({ line: focusLine - 1, ch: 0 })
+    },
+    [editorLayout]
+  )
+
   const focusTitleInputRef = useRef<() => void>()
   useEffect(() => {
     const handler = () => {
@@ -745,6 +776,13 @@ const Editor = ({
       focusEditorEventEmitter.unlisten(focusEditor)
     }
   }, [focusEditor])
+
+  useEffect(() => {
+    focusEditorHeadingEventEmitter.listen(focusEditorHeading)
+    return () => {
+      focusEditorHeadingEventEmitter.unlisten(focusEditorHeading)
+    }
+  }, [focusEditorHeading])
 
   const breadcrumbs = useMemo(() => {
     const breadcrumbs = mapTopbarBreadcrumbs(

--- a/src/cloud/components/molecules/TableOfContents/index.tsx
+++ b/src/cloud/components/molecules/TableOfContents/index.tsx
@@ -1,0 +1,115 @@
+import utilToc, { TOCOptions } from 'mdast-util-toc'
+import { Node } from 'unist'
+import React, { useCallback } from 'react'
+import unified from 'unified'
+import remarkParse from 'remark-parse'
+import rehypeSlug from 'rehype-slug'
+import remarkStringify from 'remark-stringify'
+import remarkRehype from 'remark-rehype'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import { schema } from '../../atoms/MarkdownView'
+import rehypeReact from 'rehype-react'
+import { boostHubBaseUrl } from '../../../lib/consts'
+import { usePage } from '../../../lib/stores/pageStore'
+import { focusEditorHeadingEventEmitter } from '../../../lib/utils/events'
+
+function tableOfContentsPlugin(options?: TOCOptions): (node: Node) => void {
+  const settings = options || {}
+
+  return transformer
+
+  function transformer(node: any) {
+    const result: any = utilToc(node, settings)
+
+    if (!result.map) {
+      return
+    }
+    node.children = [result.map]
+  }
+}
+
+export function getTocFromContent(
+  content: string,
+  navigateOnClick: (heading: string) => void
+): any {
+  const rehypeReactConfig: any = {
+    createElement: React.createElement,
+    Fragment: React.Fragment,
+    components: {
+      a: ({ href, children }: any) => {
+        if ((href || '').toLocaleLowerCase().startsWith('#')) {
+          const headingName: string = href.substring(1)
+          return (
+            <a
+              href={'#'}
+              onClick={(e) => {
+                e.preventDefault()
+                navigateOnClick(headingName)
+                return false
+              }}
+            >
+              {children}
+            </a>
+          )
+        }
+        if (
+          (href || '')
+            .toLocaleLowerCase()
+            .startsWith((boostHubBaseUrl || '').toLocaleLowerCase())
+        ) {
+          return <a href={href}>{children}</a>
+        }
+        return (
+          <a href={href} target='_blank' rel='noopener noreferrer'>
+            {children}
+          </a>
+        )
+      },
+    },
+  }
+
+  const newMarkdown = unified()
+    .use(remarkParse)
+    .use(rehypeSlug)
+    .use(tableOfContentsPlugin)
+    .use(remarkStringify)
+    .processSync(content)
+
+  const file = unified()
+    .use(remarkParse)
+    .use(remarkRehype, {
+      allowDangerousHtml: true,
+    })
+    .use(rehypeRaw)
+    .use(rehypeSlug)
+    .use(rehypeSanitize, schema)
+    .use(rehypeReact, rehypeReactConfig)
+    .processSync(newMarkdown)
+
+  const tocContent = (file.result || file.toString()) as any
+  return tocContent
+}
+
+interface TableOfContentsProps {
+  content: string
+}
+
+export const TableOfContents = ({ content }: TableOfContentsProps) => {
+  const { pageDoc, team } = usePage()
+
+  const navigateToDocHeading = useCallback(
+    (headingName) => {
+      if (team != null && pageDoc != null) {
+        focusEditorHeadingEventEmitter.dispatch({ heading: headingName })
+      }
+    },
+    [pageDoc, team]
+  )
+
+  return (
+    <div>
+      {getTocFromContent(content, (heading) => navigateToDocHeading(heading))}
+    </div>
+  )
+}

--- a/src/cloud/lib/utils/events.ts
+++ b/src/cloud/lib/utils/events.ts
@@ -49,6 +49,10 @@ export const focusTitleEventEmitter = createCustomEventEmitter('focus-title')
 
 export const focusEditorEventEmitter = createCustomEventEmitter('focus-editor')
 
+export const focusEditorHeadingEventEmitter = createCustomEventEmitter<{
+  heading: string
+}>('focus-editor-location')
+
 export const togglePreviewModeEventEmitter = createCustomEventEmitter(
   'toggle-preview-mode'
 )


### PR DESCRIPTION
Add linkable headers custom link
Add event for firing focus heading

Tested in dev desktop app (cloud space)
Tested in webapp (cloud space)

Workflow:
1. User creates document with headings (h1-h6 - depest level 6, can be changed later)
2. User adds toc with shortcode `[[toc]]`
2. User clicks on markdown preview links and navigates to editor heading location
3. User disables sync and clicks on links (only focuses in editor, markdown preview stays where it is)

Example: 
![image](https://user-images.githubusercontent.com/18196945/124035691-2d022280-d9fd-11eb-9d1d-11d055f41c92.png)
