### PR TITLE
Implement drag and drop based order in sidebar for local space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@stripe/react-stripe-js": "^1.2.0",
         "@stripe/stripe-js": "^1.11.0",
         "@types/react-color": "^3.0.4",
+        "array-move": "^2.2.1",
         "aws-amplify": "^4.0.3",
         "chart.js": "^2.9.4",
         "classcat": "^4.0.2",
@@ -21254,6 +21255,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-move": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-2.2.2.tgz",
+      "integrity": "sha512-lKc6C+nsOSA1o7eHSP/HshlGDYUI7QKyaus5kPDm2zEEPQID9xlspnraLR8l+rDlqg9mGo8ziE7F8TEnF6D3Tw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/array-union": {
@@ -67484,6 +67496,11 @@
         "es-abstract": "^1.17.0",
         "is-string": "^1.0.5"
       }
+    },
+    "array-move": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-2.2.2.tgz",
+      "integrity": "sha512-lKc6C+nsOSA1o7eHSP/HshlGDYUI7QKyaus5kPDm2zEEPQID9xlspnraLR8l+rDlqg9mGo8ziE7F8TEnF6D3Tw=="
     },
     "array-union": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "@stripe/react-stripe-js": "^1.2.0",
     "@stripe/stripe-js": "^1.11.0",
     "@types/react-color": "^3.0.4",
+    "array-move": "^2.2.1",
     "aws-amplify": "^4.0.3",
     "chart.js": "^2.9.4",
     "classcat": "^4.0.2",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -54,6 +54,7 @@ import CloudIntroModal from './organisms/CloudIntroModal'
 import AppNavigator from './organisms/AppNavigator'
 import Toast from '../shared/components/organisms/Toast'
 import styled from '../shared/lib/styled'
+import { useToast } from '../shared/lib/stores/toast'
 
 const LoadingText = styled.div`
   margin: 30px;
@@ -69,7 +70,7 @@ const AppContainer = styled.div`
 `
 
 const App = () => {
-  const { initialize, storageMap } = useDb()
+  const { initialize, storageMap, getUninitializedStorageData } = useDb()
   const { push, pathname } = useRouter()
   const [initialized, setInitialized] = useState(false)
   const { setGeneralStatus, generalStatus } = useGeneralStatus()
@@ -82,6 +83,7 @@ const App = () => {
   const routeParams = useRouteParams()
   const { navigate: navigateToStorage } = useStorageRouter()
   const { messageBox } = useDialog()
+  const { pushMessage } = useToast()
 
   useEffectOnce(() => {
     const fetchDesktopGlobalDataOfCloud = async () => {
@@ -208,8 +210,21 @@ const App = () => {
           }
         }
         setInitialized(true)
+
+        // notify on failed initializations
+        const uninitializedStorageData = await getUninitializedStorageData()
+        if (uninitializedStorageData.length > 0) {
+          pushMessage({
+            title: 'Error',
+            description: `Failed to initialize some storages, please check console for more info.`,
+          })
+        }
       })
       .catch((error) => {
+        pushMessage({
+          title: 'Error',
+          description: `Failed to initialize some storages, please check console for more info.`,
+        })
         console.error(error)
       })
   })

--- a/src/components/organisms/FolderDetail.tsx
+++ b/src/components/organisms/FolderDetail.tsx
@@ -18,6 +18,7 @@ import {
   selectStyle,
 } from '../../shared/lib/styled/styleFunctions'
 import styled from '../../shared/lib/styled'
+import { NOTE_ID_PREFIX } from '../../lib/db/consts'
 
 interface FolderDetailProps {
   storage: NoteStorage
@@ -46,7 +47,11 @@ const FolderDetail = ({ storage, folderPathname }: FolderDetailProps) => {
       return []
     }
 
-    return [...folder.noteIdSet]
+    return [
+      ...(folder.orderedIds || []).filter((orderId) =>
+        orderId.startsWith(NOTE_ID_PREFIX)
+      ),
+    ]
       .reduce((notes, noteId) => {
         const note = storage.noteMap[noteId]
         if (note != null && !note.trashed) {

--- a/src/components/organisms/SidebarContainer.tsx
+++ b/src/components/organisms/SidebarContainer.tsx
@@ -30,13 +30,11 @@ import { useTranslation } from 'react-i18next'
 import { useSearchModal } from '../../lib/searchModal'
 import styled from '../../shared/lib/styled'
 import cc from 'classcat'
+import { SidebarTreeSortingOrders } from '../../shared/lib/sidebar'
 import { useGeneralStatus } from '../../lib/generalStatus'
 import { AppUser } from '../../shared/lib/mappers/users'
 import { useLocalUI } from '../../lib/v2/hooks/local/useLocalUI'
-import {
-  mapTree,
-  SidebarTreeSortingOrders,
-} from '../../lib/v2/mappers/local/sidebarTree'
+import { mapTree } from '../../lib/v2/mappers/local/sidebarTree'
 import { useLocalDB } from '../../lib/v2/hooks/local/useLocalDB'
 import { useLocalDnd } from '../../lib/v2/hooks/local/useLocalDnd'
 import { CollapsableType } from '../../lib/v2/stores/sidebarCollapse'
@@ -293,14 +291,22 @@ const SidebarContainer = ({
   )
 
   const getFoldEvents = useCallback(
-    (type: CollapsableType, key: string) => {
+    (type: CollapsableType, key: string, reversed?: boolean) => {
+      if (reversed) {
+        return {
+          fold: () => unfoldItem(type, key),
+          unfold: () => foldItem(type, key),
+          toggle: () => toggleItem(type, key),
+        }
+      }
+
       return {
         fold: () => foldItem(type, key),
         unfold: () => unfoldItem(type, key),
         toggle: () => toggleItem(type, key),
       }
     },
-    [foldItem, unfoldItem, toggleItem]
+    [toggleItem, unfoldItem, foldItem]
   )
 
   const tree = useMemo(() => {
@@ -356,11 +362,13 @@ const SidebarContainer = ({
   const sidebarHeaderControls: SidebarControls = useMemo(() => {
     return {
       'View Options': (tree || []).map((category) => {
+        const key = (category.label || '').toLocaleLowerCase()
+        const hideKey = `hide-${key}`
         return {
           type: 'check',
           label: category.label,
-          checked: !sideBarOpenedLinksIdsSet.has(`hide-${category.label}`),
-          onClick: () => toggleItem('links', `hide-${category.label}`),
+          checked: !sideBarOpenedLinksIdsSet.has(hideKey),
+          onClick: () => toggleItem('links', hideKey),
         }
       }),
       Sorting: Object.values(SidebarTreeSortingOrders).map((sort) => {

--- a/src/lib/db/PouchNoteDb.spec.ts
+++ b/src/lib/db/PouchNoteDb.spec.ts
@@ -1,6 +1,12 @@
 import PouchNoteDb from './PouchNoteDb'
 import PouchDB from './PouchDB'
-import { getFolderId, getTagId, generateNoteId, getNow } from './utils'
+import {
+  getFolderId,
+  getTagId,
+  generateNoteId,
+  getNow,
+  generateFolderId,
+} from './utils'
 import { sortNotesByKeys } from '../sort'
 import { NoteDoc, FolderDoc, ExceptRev } from './types'
 
@@ -27,6 +33,7 @@ describe('PouchNoteDb', () => {
       const now = new Date().toISOString()
       await noteDb.pouchDb.put<FolderDoc>({
         _id: getFolderId('/test'),
+        _realId: generateFolderId(),
         createdAt: now,
         updatedAt: now,
         data: {},

--- a/src/lib/db/PouchNoteDb.ts
+++ b/src/lib/db/PouchNoteDb.ts
@@ -30,6 +30,7 @@ import {
   getTagName,
   values,
   isSubPathname,
+  generateFolderId,
 } from './utils'
 import { FOLDER_ID_PREFIX, ATTACHMENTS_ID } from './consts'
 import NoteDb from './NoteDb'
@@ -103,6 +104,7 @@ export default class PouchNoteDb implements NoteDb {
     const now = getNow()
     const folderDocProps = {
       ...(folder || {
+        _realId: generateFolderId(),
         _id: getFolderId(pathname),
         createdAt: now,
         data: {},
@@ -113,12 +115,23 @@ export default class PouchNoteDb implements NoteDb {
     const { rev } = await this.pouchDb.put(folderDocProps)
 
     return {
+      _realId: folderDocProps._realId,
       _id: folderDocProps._id,
       createdAt: folderDocProps.createdAt,
       updatedAt: folderDocProps.updatedAt,
       data: folderDocProps.data,
       _rev: rev,
     }
+  }
+
+  async updateFolderOrderedIds(
+    folderId: string,
+    orderedIds: string[]
+  ): Promise<FolderDoc | undefined> {
+    console.warn(
+      'Ordered IDs not supported in PouchDB' + folderId + ' ' + orderedIds
+    )
+    return undefined
   }
 
   async renameFolder(
@@ -178,10 +191,12 @@ export default class PouchNoteDb implements NoteDb {
           })
         )
       )
+      // todo: [komediruzecki-14. 07. 2021.] See if we need to handle POUCH DB noteId set and other things
+      //  or just remove completely and don't allow any actio in pouch DB storage
       updatedFolders.push({
         ...newFolder,
         pathname: destinationPathname,
-        noteIdSet: new Set(rewrittenNotes.map((note) => note._id)),
+        // noteIdSet: new Set(rewrittenNotes.map((note) => note._id)),
       })
       updatedNotes.push(...rewrittenNotes)
     }

--- a/src/lib/db/createStore.ts
+++ b/src/lib/db/createStore.ts
@@ -1,39 +1,43 @@
 import {
-  NoteStorage,
-  PouchNoteStorageData,
-  ObjectMap,
+  Attachment,
+  FolderDoc,
+  LiteStorageStorageItem,
   NoteDoc,
   NoteDocEditibleProps,
   NoteDocImportableProps,
+  NoteStorage,
+  NoteStorageData,
+  ObjectMap,
   PopulatedFolderDoc,
   PopulatedTagDoc,
-  Attachment,
+  PouchNoteStorageData,
   TagDoc,
-  NoteStorageData,
   TagDocEditibleProps,
-  FolderDoc,
 } from './types'
-import { useState, useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import ow from 'ow'
-import { schema, isValid } from '../predicates'
+import { isValid, schema } from '../predicates'
 import PouchNoteDb from './PouchNoteDb'
 import {
+  entries,
+  getAllParentFolderPathnames,
   getFolderPathname,
   getParentFolderPathname,
-  getAllParentFolderPathnames,
-  entries,
+  isDirectSubPathname,
+  mapStorageToLiteStorageData,
+  values,
 } from './utils'
 import { generateId } from '../string'
 import PouchDB from './PouchDB'
 import { LiteStorage } from 'ltstrg'
-import { produce, enableMapSet } from 'immer'
+import { enableMapSet, produce } from 'immer'
 import { RouterStore } from '../router'
-import { values } from './utils'
 import { storageDataListKey } from '../localStorageKeys'
 import { TAG_ID_PREFIX } from './consts'
 import { difference } from 'ramda'
 import { useRefState } from '../hooks'
 import FSNoteDb from './FSNoteDb'
+import { removeDuplicates } from '../../shared/lib/utils/array'
 
 enableMapSet()
 
@@ -45,6 +49,7 @@ export interface DbStore {
     name: string,
     props?: { type: 'fs'; location: string }
   ) => Promise<NoteStorage>
+  getUninitializedStorageData: () => Promise<LiteStorageStorageItem[]>
   removeStorage: (id: string) => Promise<void>
   renameStorage: (id: string, name: string) => void
   createFolder: (
@@ -56,6 +61,11 @@ export interface DbStore {
     pathname: string,
     newName: string
   ) => Promise<void>
+  updateFolderOrderedIds: (
+    storageId: string,
+    folderId: string,
+    newOrderedIds: string[]
+  ) => Promise<FolderDoc | undefined>
   removeFolder: (storageId: string, pathname: string) => Promise<void>
   createNote(
     storageId: string,
@@ -104,6 +114,9 @@ export function createDbStoreCreator(
     const router = routerHook()
     const currentPathnameWithoutNoteId = pathnameWithoutNoteIdGetter()
     const [initialized, setInitialized] = useState(false)
+    const [uninitializedStoragesData, setUninitializedStoragesData] = useState<
+      LiteStorageStorageItem[]
+    >([])
     const [storageMap, storageMapRef, setStorageMap] = useRefState<
       ObjectMap<NoteStorage>
     >({})
@@ -130,14 +143,16 @@ export function createDbStoreCreator(
         const folder: PopulatedFolderDoc =
           storage.folderMap[noteDoc.folderPathname] == null
             ? ({
+                // todo: [komediruzecki-11/07/2021] FIXME: Should be upsert folder? Probably never executed code
                 ...(await storage.db.getFolder(noteDoc.folderPathname)!),
                 pathname: noteDoc.folderPathname,
-                noteIdSet: new Set([noteDoc._id]),
+                orderedIds: [noteDoc._id],
               } as PopulatedFolderDoc)
             : {
                 ...storage.folderMap[noteDoc.folderPathname]!,
-                noteIdSet: new Set([
-                  ...storage.folderMap[noteDoc.folderPathname]!.noteIdSet,
+                orderedIds: removeDuplicates([
+                  ...(storage.folderMap[noteDoc.folderPathname]!.orderedIds ||
+                    []),
                   noteDoc._id,
                 ]),
               }
@@ -172,7 +187,6 @@ export function createDbStoreCreator(
               draft[storageId]!.folderMap[aPathname] = {
                 ...folder,
                 pathname: aPathname,
-                noteIdSet: new Set(),
               }
             })
             draft[storageId]!.folderMap[noteDoc.folderPathname] = folder
@@ -199,7 +213,7 @@ export function createDbStoreCreator(
           ...props,
         })
 
-        let newStorageMap: ObjectMap<NoteStorage>
+        let newStorageMap: ObjectMap<NoteStorage> = {}
         setStorageMap((prevStorageMap) => {
           newStorageMap = produce(prevStorageMap, (draft) => {
             draft[id] = storage
@@ -208,29 +222,48 @@ export function createDbStoreCreator(
           return newStorageMap
         })
 
-        saveStorageDataList(liteStorage, newStorageMap!)
+        const localStorageStorageDataList: LiteStorageStorageItem[] = [
+          ...values(newStorageMap).map(mapStorageToLiteStorageData),
+          ...uninitializedStoragesData,
+        ]
+        saveStorageDataList(liteStorage, localStorageStorageDataList)
         return storage
       },
-      [setStorageMap]
+      [setStorageMap, uninitializedStoragesData]
     )
 
     const initialize = useCallback(async () => {
       const storageDataList = getStorageDataListOrFix(liteStorage)
 
+      const storagesFailedAtInit: LiteStorageStorageItem[] = []
       const prepared = await Promise.all(
-        storageDataList.map((storage) => prepareStorage(storage))
+        storageDataList.map((storage) =>
+          prepareStorage(storage).catch((err) => {
+            console.warn(`Skipping loading storage: '${storage.name}'!`)
+            console.warn('[ERROR]', err)
+            storagesFailedAtInit.push(mapStorageToLiteStorageData(storage))
+            return null
+          })
+        )
       )
+
+      setUninitializedStoragesData(storagesFailedAtInit)
       const storageMap = prepared.reduce((map, storage) => {
-        map[storage.id] = storage
+        if (storage != null) {
+          map[storage.id] = storage
+        }
         return map
       }, {} as ObjectMap<NoteStorage>)
 
-      saveStorageDataList(liteStorage, storageMap)
+      const localStorageStorageDataList: LiteStorageStorageItem[] = [
+        ...values(storageMap).map(mapStorageToLiteStorageData),
+        ...storagesFailedAtInit,
+      ]
+      saveStorageDataList(liteStorage, localStorageStorageDataList)
       setStorageMap(storageMap)
       setInitialized(true)
-
       return storageMap
-    }, [setStorageMap])
+    }, [setStorageMap, setUninitializedStoragesData])
 
     const removeStorage = useCallback(
       async (id: string) => {
@@ -243,7 +276,7 @@ export function createDbStoreCreator(
           await storage.db.pouchDb.destroy()
         }
 
-        let newStorageMap: ObjectMap<NoteStorage>
+        let newStorageMap: ObjectMap<NoteStorage> = {}
         setStorageMap((prevStorageMap) => {
           newStorageMap = produce(prevStorageMap, (draft) => {
             delete draft[id]
@@ -252,11 +285,15 @@ export function createDbStoreCreator(
           return newStorageMap
         })
 
-        saveStorageDataList(liteStorage, newStorageMap!)
+        const localStorageStorageDataList: LiteStorageStorageItem[] = [
+          ...values(newStorageMap).map(mapStorageToLiteStorageData),
+          ...uninitializedStoragesData,
+        ]
+        saveStorageDataList(liteStorage, localStorageStorageDataList)
       },
       // FIXME: The callback regenerates every storageMap change.
       // We should move the method to NoteStorage so the method instantiate only once.
-      [setStorageMap, storageMap]
+      [setStorageMap, storageMap, uninitializedStoragesData]
     )
 
     const renameStorage = useCallback(
@@ -273,9 +310,14 @@ export function createDbStoreCreator(
           })
           return newStorageMap
         })
-        saveStorageDataList(liteStorage, newStorageMap)
+
+        const localStorageStorageDataList: LiteStorageStorageItem[] = [
+          ...values(newStorageMap).map(mapStorageToLiteStorageData),
+          ...uninitializedStoragesData,
+        ]
+        saveStorageDataList(liteStorage, localStorageStorageDataList)
       },
-      [setStorageMap, storageMap]
+      [setStorageMap, storageMap, uninitializedStoragesData]
     )
 
     const createFolder = useCallback(
@@ -295,17 +337,44 @@ export function createDbStoreCreator(
           getAllParentFolderPathnames(pathname)
         )
         const createdFolders = [folder, ...parentFolders].reverse()
+        const createdFoldersWithOrderedIds: FolderDoc[] = []
+
+        for (const aFolder of createdFolders) {
+          const aPathname = getFolderPathname(aFolder._id)
+          if (storage.folderMap[aPathname] != null) {
+            continue
+          }
+          const parentFolder =
+            storage.folderMap[getParentFolderPathname(aPathname)]
+          if (parentFolder == null) {
+            continue
+          }
+          const previousOrderedIds = parentFolder.orderedIds || []
+          const newOrderedIds = removeDuplicates([
+            ...previousOrderedIds,
+            aFolder._realId,
+          ])
+          const updatedFolder = await storage.db.upsertFolder(
+            parentFolder.pathname,
+            {
+              orderedIds: newOrderedIds,
+            }
+          )
+          if (updatedFolder != null) {
+            createdFoldersWithOrderedIds.push(updatedFolder)
+          }
+        }
+
+        // add last one which isn't updated - no ordered IDs to update
+        createdFoldersWithOrderedIds.push(folder)
 
         setStorageMap(
           produce((draft: ObjectMap<NoteStorage>) => {
-            createdFolders.forEach((aFolder) => {
+            createdFoldersWithOrderedIds.forEach((aFolder) => {
               const aPathname = getFolderPathname(aFolder._id)
-              if (storage.folderMap[aPathname] == null) {
-                draft[storageId]!.folderMap[aPathname] = {
-                  ...aFolder,
-                  pathname: aPathname,
-                  noteIdSet: new Set(),
-                }
+              draft[storageId]!.folderMap[aPathname] = {
+                ...aFolder,
+                pathname: aPathname,
               }
             })
           })
@@ -340,6 +409,38 @@ export function createDbStoreCreator(
             })
           })
         )
+      },
+      [storageMap, setStorageMap]
+    )
+
+    const updateFolderOrderedIds = useCallback(
+      async (workspaceId: string, resourceId: string, orderedIds: string[]) => {
+        const storage = storageMap[workspaceId]
+        if (storage == null) {
+          return
+        }
+        const folderPathname = getFolderPathname(resourceId)
+        const populatedFolderDoc = storage.folderMap[folderPathname]
+        if (populatedFolderDoc == null) {
+          throw new Error('Missing folder to update: ' + resourceId)
+        }
+        const folderDoc = await storage.db.updateFolderOrderedIds(
+          resourceId,
+          orderedIds
+        )
+
+        if (folderDoc != null) {
+          setStorageMap(
+            produce((draft: ObjectMap<NoteStorage>) => {
+              draft[storage.id]!.folderMap[populatedFolderDoc.pathname] = {
+                pathname: populatedFolderDoc.pathname,
+                ...folderDoc,
+              }
+            })
+          )
+        }
+
+        return folderDoc
       },
       [storageMap, setStorageMap]
     )
@@ -454,16 +555,23 @@ export function createDbStoreCreator(
           const previousFolder =
             storage.folderMap[previousNoteDoc.folderPathname]
           if (previousFolder != null) {
-            const newNoteIdSetForPreviousFolder = new Set(
-              previousFolder.noteIdSet
+            const previousOrderedIds = previousFolder.orderedIds || []
+            const newOrderedIdsForParent = removeDuplicates(
+              previousOrderedIds.filter((orderId) => noteDoc._id != orderId)
             )
-            newNoteIdSetForPreviousFolder.delete(noteId)
+            const updatedPreviousFolder = await storage.db.updateFolderOrderedIds(
+              previousFolder._id,
+              newOrderedIdsForParent
+            )
             folderListToRefresh.push({
               ...previousFolder,
-              noteIdSet: newNoteIdSetForPreviousFolder,
+              ...updatedPreviousFolder,
             })
           }
         }
+
+        // todo: [komediruzecki-14/07/2021] this parent folders update should not happen - but if someone calls update note with
+        //  folders not existing, we should update its ordered IDs as well - not done currently (none should call it like this)
         const parentFolderPathnamesToCheck = [
           ...getAllParentFolderPathnames(noteDoc.folderPathname),
         ].filter((aPathname) => storage.folderMap[aPathname] == null)
@@ -482,17 +590,20 @@ export function createDbStoreCreator(
         const folder: PopulatedFolderDoc =
           storage.folderMap[noteDoc.folderPathname] == null
             ? ({
+                // todo: [komediruzecki-11/07/2021] Should be upsert folder? Not executed?
                 ...(await storage.db.getFolder(noteDoc.folderPathname)!),
                 pathname: noteDoc.folderPathname,
-                noteIdSet: new Set([noteDoc._id]),
+                orderedIds: [noteDoc._id],
               } as PopulatedFolderDoc)
             : {
                 ...storage.folderMap[noteDoc.folderPathname]!,
-                noteIdSet: new Set([
-                  ...storage.folderMap[noteDoc.folderPathname]!.noteIdSet,
+                orderedIds: removeDuplicates([
+                  ...(storage.folderMap[noteDoc.folderPathname]!.orderedIds ||
+                    []),
                   noteDoc._id,
                 ]),
               }
+
         folderListToRefresh.push(folder)
 
         const removedTags: ObjectMap<PopulatedTagDoc> = difference(
@@ -599,13 +710,8 @@ export function createDbStoreCreator(
         let modifiedFolderInOriginalStorage =
           originalStorage.folderMap[originalNote.folderPathname]
         if (modifiedFolderInOriginalStorage != null) {
-          const newNoteIdSet = new Set(
-            modifiedFolderInOriginalStorage.noteIdSet
-          )
-          newNoteIdSet.delete(originalNote._id)
           modifiedFolderInOriginalStorage = {
             ...modifiedFolderInOriginalStorage,
-            noteIdSet: newNoteIdSet,
           }
         }
 
@@ -618,13 +724,8 @@ export function createDbStoreCreator(
                 pathname: targetFolderPathname,
               }
             : targetStorage.folderMap[targetFolderPathname]!
-        const newNoteIdSetForTargetFolder = new Set([
-          ...targetFolder.noteIdSet,
-          newNote._id,
-        ])
         modifiedFoldersInTargetStorage.push({
           ...targetFolder,
-          noteIdSet: newNoteIdSetForTargetFolder,
         })
 
         const parentFolderPathnamesToCheck = [
@@ -702,14 +803,21 @@ export function createDbStoreCreator(
         }
 
         let folder: PopulatedFolderDoc | undefined
-        if (storage.folderMap[noteDoc.folderPathname] != null) {
-          const newFolderNoteIdSet = new Set(
-            storage.folderMap[noteDoc.folderPathname]!.noteIdSet
+        const parentFolder = storage.folderMap[noteDoc.folderPathname]
+        if (parentFolder != null) {
+          const previousOrderedIds = parentFolder.orderedIds || []
+          const newOrderedIdsForParent = removeDuplicates(
+            previousOrderedIds.filter((orderId) => noteDoc._id != orderId)
           )
-          newFolderNoteIdSet.delete(noteDoc._id)
+          // update folder ordered IDs in database
+          const updatedFolder = await storage.db.updateFolderOrderedIds(
+            parentFolder._id,
+            newOrderedIdsForParent
+          )
           folder = {
-            ...storage.folderMap[noteDoc.folderPathname]!,
-            noteIdSet: newFolderNoteIdSet,
+            ...(updatedFolder || storage.folderMap[noteDoc.folderPathname]!),
+            pathname: noteDoc.folderPathname,
+            orderedIds: newOrderedIdsForParent,
           }
         }
 
@@ -761,28 +869,61 @@ export function createDbStoreCreator(
         const folder: PopulatedFolderDoc =
           storage.folderMap[noteDoc.folderPathname] == null
             ? ({
-                ...(await storage.db.getFolder(noteDoc.folderPathname)!),
+                ...(await storage.db.upsertFolder(noteDoc.folderPathname)),
                 pathname: noteDoc.folderPathname,
-                noteIdSet: new Set([noteDoc._id]),
+                orderedIds: [noteDoc._id],
               } as PopulatedFolderDoc)
             : {
                 ...storage.folderMap[noteDoc.folderPathname]!,
-                noteIdSet: new Set([
-                  ...storage.folderMap[noteDoc.folderPathname]!.noteIdSet,
+                orderedIds: removeDuplicates([
+                  ...(storage.folderMap[noteDoc.folderPathname]!.orderedIds ||
+                    []),
                   noteDoc._id,
                 ]),
               }
         const parentFolderPathnames = getAllParentFolderPathnames(
           noteDoc.folderPathname
         )
-        const missingFolders: PopulatedFolderDoc[] = []
+        const foldersToUpdate: PopulatedFolderDoc[] = []
+        const foldersToUpdateParentOrderedIds: PopulatedFolderDoc[] = [folder]
         for (const parentFolderPathname of parentFolderPathnames) {
           if (storage.folderMap[parentFolderPathname] == null) {
-            missingFolders.push({
-              ...(await storage.db.getFolder(parentFolderPathname)),
+            const missingFolder = await storage.db.upsertFolder(
+              parentFolderPathname
+            )
+
+            const missingFolderPopulatedDoc = {
+              ...missingFolder,
               pathname: parentFolderPathname,
               noteIdSet: new Set(),
-            } as PopulatedFolderDoc)
+            } as PopulatedFolderDoc
+            foldersToUpdate.push(missingFolderPopulatedDoc)
+            foldersToUpdateParentOrderedIds.push(missingFolderPopulatedDoc)
+          }
+        }
+
+        for (const folder of foldersToUpdateParentOrderedIds) {
+          const parentFolder = await storage.db.getFolder(
+            getParentFolderPathname(folder.pathname)
+          )
+          if (parentFolder == null) {
+            continue
+          }
+          const previousOrderedIds = parentFolder.orderedIds || []
+          const newOrderedIds = removeDuplicates([
+            ...previousOrderedIds,
+            folder._realId,
+          ])
+
+          const updatedParentFolder = await storage.db.updateFolderOrderedIds(
+            parentFolder._id,
+            newOrderedIds
+          )
+          if (updatedParentFolder != null) {
+            foldersToUpdate.push({
+              ...updatedParentFolder,
+              pathname: getFolderPathname(parentFolder._id),
+            })
           }
         }
 
@@ -812,15 +953,16 @@ export function createDbStoreCreator(
           produce((draft: ObjectMap<NoteStorage>) => {
             draft[storageId]!.noteMap[noteDoc._id] = noteDoc
             draft[storageId]!.folderMap[noteDoc.folderPathname] = folder
-            missingFolders.forEach((missingFolder) => {
+            foldersToUpdate.forEach((folderToUpdate) => {
               draft[storageId]!.folderMap[
-                missingFolder.pathname
-              ] = missingFolder
+                folderToUpdate.pathname
+              ] = folderToUpdate
             })
             draft[storageId]!.tagMap = {
               ...storage.tagMap,
               ...modifiedTags,
             }
+
             if (noteDoc.data.bookmarked) {
               const bookmarkedItemIdSet = new Set(storage.bookmarkedItemIds)
               bookmarkedItemIdSet.add(noteDoc._id)
@@ -834,6 +976,7 @@ export function createDbStoreCreator(
       [storageMap, setStorageMap]
     )
 
+    // unused function - but should be fixed for ordered IDs if ever used!
     const purgeNote = useCallback(
       async (storageId: string, noteId: string) => {
         const storage = storageMap[storageId]
@@ -854,12 +997,8 @@ export function createDbStoreCreator(
             delete noteMap[noteId]
             draft[storageId]!.noteMap = noteMap
 
-            const folder = storage.folderMap[note.folderPathname]
-            if (folder != null) {
-              const newFolderNoteIdSet = new Set(folder.noteIdSet)
-              newFolderNoteIdSet.delete(note._id)
-              folder.noteIdSet = newFolderNoteIdSet
-            }
+            // todo: [komediruzecki-14/07/2021] On note purge remove ordered ID from parent folder
+            //  here note ID set was updated - do we need ordered IDs update
 
             note.tags.forEach((tagName) => {
               const tag = storage.tagMap[tagName]
@@ -1107,6 +1246,10 @@ export function createDbStoreCreator(
       [setStorageMap, storageMapRef]
     )
 
+    const getUninitializedStorageData = useCallback(async () => {
+      return uninitializedStoragesData
+    }, [uninitializedStoragesData])
+
     return {
       initialized,
       storageMap,
@@ -1116,6 +1259,7 @@ export function createDbStoreCreator(
       renameStorage,
       createFolder,
       renameFolder,
+      updateFolderOrderedIds,
       removeFolder,
       createNote,
       updateNote,
@@ -1130,6 +1274,7 @@ export function createDbStoreCreator(
       removeAttachment,
       bookmarkNote,
       unbookmarkNote,
+      getUninitializedStorageData,
     }
   }
 }
@@ -1175,29 +1320,9 @@ function getStorageDataListOrFix(liteStorage: LiteStorage): NoteStorageData[] {
 
 function saveStorageDataList(
   liteStorage: LiteStorage,
-  storageMap: ObjectMap<NoteStorage>
+  storageData: LiteStorageStorageItem[]
 ) {
-  liteStorage.setItem(
-    storageDataListKey,
-    JSON.stringify(
-      values(storageMap).map((storage) => {
-        const { id, name } = storage
-        if (storage.type === 'fs') {
-          return {
-            id,
-            name,
-            type: 'fs',
-            location: storage.location,
-          }
-        }
-        return {
-          id,
-          name,
-          cloudStorage: storage.cloudStorage,
-        }
-      })
-    )
-  )
+  liteStorage.setItem(storageDataListKey, JSON.stringify(storageData))
 }
 
 async function prepareStorage(
@@ -1216,17 +1341,22 @@ async function prepareStorage(
         )
   await db.init()
 
+  const foldersToUpdateOrderedIds: string[] = []
+
   const { noteMap, folderMap, tagMap } = await db.getAllDocsMap()
   const attachmentMap = await db.getAttachmentMap()
   const populatedFolderMap = entries(folderMap).reduce<
     ObjectMap<PopulatedFolderDoc>
   >((map, [pathname, folderDoc]) => {
+    if (folderDoc.orderedIds == null && storageData.type == 'fs') {
+      folderDoc.orderedIds = []
+      foldersToUpdateOrderedIds.push(pathname)
+    }
+
     map[pathname] = {
       ...folderDoc,
       pathname,
-      noteIdSet: new Set(),
     }
-
     return map
   }, {})
   const populatedTagMap = entries(tagMap).reduce<ObjectMap<PopulatedTagDoc>>(
@@ -1242,11 +1372,16 @@ async function prepareStorage(
   )
   const bookmarkedIdSet = new Set<string>()
 
+  const folderNoteIds = new Map<string, Set<string>>()
   for (const noteDoc of values(noteMap)) {
     if (noteDoc.trashed) {
       continue
     }
-    populatedFolderMap[noteDoc.folderPathname]!.noteIdSet.add(noteDoc._id)
+    if (!folderNoteIds.has(noteDoc.folderPathname)) {
+      folderNoteIds.set(noteDoc.folderPathname, new Set([noteDoc._id]))
+    } else {
+      folderNoteIds.get(noteDoc.folderPathname)!.add(noteDoc._id)
+    }
     noteDoc.tags.forEach((tag) => {
       populatedTagMap[tag]!.noteIdSet.add(noteDoc._id)
     })
@@ -1257,6 +1392,41 @@ async function prepareStorage(
   const bookmarkedItemIds = [...bookmarkedIdSet]
 
   if (storageData.type === 'fs') {
+    // update folder ordered Ids if needed
+    foldersToUpdateOrderedIds.forEach((parentFolderPathname) => {
+      const subFoldersPathnames: string[] = db.getAllFolderUnderPathname(
+        parentFolderPathname
+      ) as string[]
+
+      subFoldersPathnames
+        .slice(1)
+        .filter((subFolderPathname) =>
+          isDirectSubPathname(parentFolderPathname, subFolderPathname)
+        )
+        .forEach((subFolderPathname: string) => {
+          const subFolderDoc = populatedFolderMap[subFolderPathname]
+          if (subFolderDoc != null) {
+            populatedFolderMap[parentFolderPathname]!.orderedIds!.push(
+              subFolderDoc._realId
+            )
+          }
+        })
+      const noteIDs = folderNoteIds.get(parentFolderPathname)
+      if (noteIDs != null) {
+        populatedFolderMap[parentFolderPathname]?.orderedIds!.push(...noteIDs)
+      }
+
+      // remove any duplicates even though there should not be any!
+      populatedFolderMap[parentFolderPathname]!.orderedIds! = removeDuplicates(
+        populatedFolderMap[parentFolderPathname]!.orderedIds!
+      )
+    })
+    foldersToUpdateOrderedIds.forEach((folderPathname) => {
+      const folderDoc = populatedFolderMap[folderPathname]
+      if (folderDoc != null && folderDoc.orderedIds != null) {
+        db.updateFolderOrderedIds(folderDoc._id, folderDoc.orderedIds)
+      }
+    })
     return {
       type: 'fs',
       id,

--- a/src/lib/db/patterns.ts
+++ b/src/lib/db/patterns.ts
@@ -1,5 +1,28 @@
 import { NavResource } from '../v2/interfaces/resources'
+import { getFolderPathname, getParentFolderPathname } from './utils'
+import { DraggedTo, SidebarDragState } from '../../shared/lib/dnd'
 
 export function getResourceId(source: NavResource) {
-  return source.result._id
+  if (source.type == 'folder') {
+    return source.result._realId
+  } else {
+    return source.result._id
+  }
+}
+
+export function getResourceParentPathname(
+  source: NavResource,
+  targetedPosition?: SidebarDragState
+) {
+  if (source.type == 'doc') {
+    return source.result.folderPathname
+  } else {
+    if (targetedPosition == DraggedTo.insideFolder) {
+      return getFolderPathname(source.result._id)
+    } else if (targetedPosition == DraggedTo.beforeItem) {
+      return getParentFolderPathname(getFolderPathname(source.result._id))
+    } else {
+      return getParentFolderPathname(getFolderPathname(source.result._id))
+    }
+  }
 }

--- a/src/lib/db/store.spec.ts
+++ b/src/lib/db/store.spec.ts
@@ -458,7 +458,7 @@ describe('DbStore', () => {
         expect(
           result.current.storageMap[storage!.id]!.folderMap[
             noteDoc!.folderPathname
-          ]!.noteIdSet.has(noteDoc!._id)
+          ]!.orderedIds!.indexOf(noteDoc!._id) == -1
         ).toEqual(false)
       })
     })
@@ -535,8 +535,8 @@ describe('DbStore', () => {
         expect(
           result.current.storageMap[storage!.id]!.folderMap[
             noteDoc!.folderPathname
-          ]!.noteIdSet.has(noteDoc!._id)
-        ).toEqual(false)
+          ]!.orderedIds!.indexOf(noteDoc!._id)
+        ).toEqual(-1)
       })
     })
 
@@ -589,7 +589,7 @@ describe('DbStore', () => {
         expect(
           result.current.storageMap[storage!.id]!.folderMap[
             noteDoc!.folderPathname
-          ]!.noteIdSet.has(noteDoc!._id)
+          ]!.orderedIds!.indexOf(noteDoc!._id) != -1
         ).toEqual(true)
       })
     })

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -59,12 +59,14 @@ export type NoteDoc = {
 
 export type FolderDoc = {
   _id: string // folder:${FOLDER_PATHNAME}
+  _realId: string // identification for reordering (unique across any property change)
   createdAt: string
   updatedAt: string
   _rev?: string
 } & FolderDocEditibleProps
 
 export type FolderDocEditibleProps = {
+  orderedIds?: string[]
   data: JsonObject
 }
 
@@ -116,7 +118,6 @@ export type FSNoteStorage = FSNoteStorageData &
 export type NoteStorage = PouchNoteStorage | FSNoteStorage
 export type PopulatedFolderDoc = FolderDoc & {
   pathname: string
-  noteIdSet: NoteIdSet
 }
 
 export type PopulatedTagDoc = TagDoc & {
@@ -130,4 +131,12 @@ export interface AllPopulatedDocsMap {
   tagMap: ObjectMap<PopulatedTagDoc>
   attachmentMap: ObjectMap<Attachment>
   bookmarkedItemIds: string[]
+}
+
+export interface LiteStorageStorageItem {
+  id?: string
+  name?: string
+  type?: 'fs'
+  location?: string
+  cloudStorage?: CloudNoteStorageData
 }

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -8,6 +8,8 @@ import {
   PouchNoteStorageData,
   NoteStorage,
   PopulatedTagDoc,
+  NoteStorageData,
+  LiteStorageStorageItem,
 } from './types'
 import { generateId, escapeRegExp } from '../string'
 
@@ -31,12 +33,23 @@ export function generateNoteId(): string {
   return `${NOTE_ID_PREFIX}${generateId()}`
 }
 
+export function generateFolderId(): string {
+  return `${FOLDER_ID_PREFIX}${generateId()}`
+}
+
 export function excludeNoteIdPrefix(noteId: string): string {
   return noteId.replace(new RegExp(`^${NOTE_ID_PREFIX}`), '')
 }
 
 export function excludeFileProtocol(src: string) {
   return src.replace('file://', '')
+}
+
+export function prependFolderIdPrefix(folderPathname: string): string {
+  if (new RegExp(`^${FOLDER_ID_PREFIX}`).test(folderPathname)) {
+    return folderPathname
+  }
+  return `${FOLDER_ID_PREFIX}${folderPathname}`
 }
 
 export function getWorkspaceHref(storage: NoteStorage, query?: any): string {
@@ -241,4 +254,23 @@ export function isCloudStorageData(
 
 export function normalizeTagColor(tag: PopulatedTagDoc): string {
   return typeof tag.data.color == 'string' ? tag.data.color : ''
+}
+
+export function mapStorageToLiteStorageData(
+  storage: NoteStorage | NoteStorageData
+): LiteStorageStorageItem {
+  const { id, name } = storage
+  if (storage.type === 'fs') {
+    return {
+      id,
+      name,
+      type: 'fs',
+      location: storage.location,
+    }
+  }
+  return {
+    id,
+    name,
+    cloudStorage: storage.cloudStorage,
+  }
 }

--- a/src/lib/v2/hooks/local/useLocalDB.ts
+++ b/src/lib/v2/hooks/local/useLocalDB.ts
@@ -26,6 +26,7 @@ export function useLocalDB() {
     unbookmarkNote,
     updateNote,
     renameFolder,
+    updateFolderOrderedIds,
     storageMap: workspaceMap,
   } = useDb()
   const { push } = useRouter()
@@ -145,7 +146,7 @@ export function useLocalDB() {
       await send(workspace.id, 'delete', {
         api: () => removeStorage(workspace.id),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
@@ -157,7 +158,7 @@ export function useLocalDB() {
       await send(target.workspaceId, 'delete', {
         api: () => removeFolder(target.workspaceId, target.pathname),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
@@ -169,25 +170,37 @@ export function useLocalDB() {
       return send(target.workspaceId, 'delete', {
         api: () => deleteNote(target.workspaceId, target.docId),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
     [send, deleteNote]
   )
 
-  const updateFolderApi = useCallback(
+  const renameFolderApi = useCallback(
     async (target: FolderDoc, body: UpdateFolderRequestBody) => {
       await send(target._id, 'update', {
         api: () =>
-          // generic update not available, rename instead
           renameFolder(body.workspaceId, body.oldPathname, body.newPathname),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
     [send, renameFolder]
+  )
+
+  const updateFolderOrderedIdsApi = useCallback(
+    async (resourceId, body: UpdateFolderOrderedIdsRequestBody) => {
+      await send(resourceId, 'update', {
+        api: () =>
+          updateFolderOrderedIds(body.workspaceId, resourceId, body.orderedIds),
+        cb: () => {
+          // maybe push message to notify successful update
+        },
+      })
+    },
+    [send, updateFolderOrderedIds]
   )
 
   const updateDocApi = useCallback(
@@ -195,10 +208,7 @@ export function useLocalDB() {
       await send(docId, 'update', {
         api: () => updateNote(body.workspaceId, docId, body.docProps),
         cb: () => {
-          // if (pageDoc != null && doc.id === pageDoc.id) {
-          //   setPartialPageData({ pageDoc: doc })
-          //   setCurrentPath(doc.folderPathname)
-          // }
+          // maybe push message to notify successful update
         },
       })
     },
@@ -217,7 +227,8 @@ export function useLocalDB() {
     deleteFolderApi,
     deleteDocApi,
     updateDocApi,
-    updateFolder: updateFolderApi,
+    renameFolderApi,
+    updateFolderOrderedIdsApi,
     workspaceMap,
   }
 }
@@ -242,6 +253,11 @@ export interface UpdateFolderRequestBody {
   workspaceId: string
   oldPathname: string
   newPathname: string
+}
+
+export interface UpdateFolderOrderedIdsRequestBody {
+  workspaceId: string
+  orderedIds: string[]
 }
 
 export interface UpdateDocRequestBody {

--- a/src/lib/v2/stores/sidebarCollapse/store.tsx
+++ b/src/lib/v2/stores/sidebarCollapse/store.tsx
@@ -13,7 +13,7 @@ import { useActiveStorageId } from '../../../routeParams'
 const initialContent: CollapsableContent = {
   folders: [],
   workspaces: [],
-  links: [`hide-labels`, 'hide-status'],
+  links: [],
 }
 
 function useSidebarCollapseStore(): SidebarCollapseContext {


### PR DESCRIPTION
This PR also introduces few key changes and bugfixes:
1. Storage loading is handled differently (all storages loaded nevertheless of errors, error ones stored for futher loading, any error is logged properly)
2. Fixes a bug with regex being global and thus in particular situations creates wrong list of subfolders of a parent (not all)
3. Fixes a bug with hide sidebar items, wrong keys used in SidebarContainer
4. Implements drag and drop (with ordered IDs, real Folder IDs, few createStore and FSNote DB refactors, few minor bugfixes)


Add array move lib
Implemented orderedIds and DnD handling
Add logic for moving note or doc into note target
Add basic Database updates and API for orderedIds changes
Implement ordered IDs initialization in storages
Implement ordered IDs initializatio only in FSNote
Remove excess function from createStore

Updated handling of pouch DB in createStore
Add create note update for parent folder ordered IDs

Fix direct subfolders rather than all for create subfolders function
Add implementation of trash/untrash note workspace orderedIds

Update rename folder to update ordered IDs as well
Implement createNote update of ordered IDs (workspace)
Implement createFolder update of ordered IDs (workspace and parent folders)
Implement folder reordering
Implement moving of folders across different folder
Refactor folder IDs to use real IDs
Initialize real IDs (only FSNoteDB)
Update rename folder so that it handles realIDs updates (previous and new parent folders ordered IDs update)
Refactor code to use root folder instead of workspace ordered Ids
Refactor and update for loading of storages
Some improvements on loading multiple storages and some fails
Add folder realID changing instead of reusing (also previous ordered IDs should be persisted on folder rename)
Add handling of trash/untrash regarding ordered Ids

Some ordered IDs bugfixes

Remove console logs (most of them)
Fix bug with parallel execution and parent folder creation on rename folder upsert folder calls

Remove note id set from local space

Fix bug with hiding items in sidebar (invalid key provided on callback)
Assess some todos