### PR TITLE
Add electron zoom feature

### DIFF
--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -282,10 +282,10 @@ export function getTemplateFromKeymap(
         { role: 'forcereload' },
         { role: 'toggledevtools' },
         { type: 'separator' },
-        // { role: 'resetzoom' },
-        // { role: 'zoomin' },
-        // { role: 'zoomout' },
-        // { type: 'separator' },
+        { role: 'resetzoom' },
+        { role: 'zoomin' },
+        { role: 'zoomout' },
+        { type: 'separator' },
         { role: 'togglefullscreen' },
       ] as MenuItemConstructorOptions[],
     },
@@ -293,7 +293,6 @@ export function getTemplateFromKeymap(
       label: 'Window',
       submenu: [
         { role: 'minimize' },
-        { role: 'zoom' },
         ...(mac
           ? [
               { type: 'separator' },


### PR DESCRIPTION
Add zoom reset
Add zoom in (Ctrl++)
Add zoom out (Ctrl+-)
Remove zoom menu item in Window menu (does nothing)

Test in desktop app
Zooms out
Zooms in
Zoom reset works
Menu item 'zoom' from Window file menu removed