### PR TITLE
Add expandable image in markdown preview

### DIFF
--- a/src/cloud/components/atoms/MarkdownView/index.tsx
+++ b/src/cloud/components/atoms/MarkdownView/index.tsx
@@ -46,6 +46,7 @@ import throttle from 'lodash.throttle'
 import CodeFence from '../../../../shared/components/atoms/markdown/CodeFence'
 import { agentType, sendPostMessage } from '../../../../mobile/lib/nativeMobile'
 import { TableOfContents } from '../../molecules/TableOfContents'
+import ExpandableImage from '../../../../shared/components/molecules/Image/ExpandableImage'
 
 const remarkAdmonitionOptions = {
   tag: ':::',
@@ -156,6 +157,9 @@ const MarkdownView = ({
       createElement: React.createElement,
       Fragment: React.Fragment,
       components: {
+        img: ({ src }: any) => {
+          return <ExpandableImage src={src} />
+        },
         a: ({ href, children }: any) => {
           if (agentType === 'ios-native' || agentType === 'android-native') {
             return (

--- a/src/shared/components/molecules/Image/ExpandableImage.tsx
+++ b/src/shared/components/molecules/Image/ExpandableImage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import styled from '../../../lib/styled'
 import Image from '../../../../components/atoms/Image'
-import { mdiArrowExpandAll, mdiClose } from '@mdi/js'
+import { mdiArrowExpandAll } from '@mdi/js'
 import Icon from '../../atoms/Icon'
 import { flexCenter } from '../../../lib/styled/styleFunctions'
 import {
@@ -9,7 +9,8 @@ import {
   preventKeyboardEventPropagation,
   useGlobalKeyDownHandler,
 } from '../../../../cloud/lib/keyboard'
-import Button from '../../atoms/Button'
+import { useModal } from '../../../lib/stores/modal'
+import ImagePreview from './ImagePreview'
 
 interface ExpandableImageProps {
   src: string
@@ -20,10 +21,16 @@ const ExpandableImage = ({ src }: ExpandableImageProps) => {
   const [showingEnlargedImage, setShowingEnlargedImage] = useState<boolean>(
     false
   )
-
+  const { closeLastModal, openModal } = useModal()
   const onImageExpand = useCallback(() => {
+    closeLastModal()
+
+    openModal(<ImagePreview src={src} />, {
+      showCloseIcon: true,
+      width: 'full',
+    })
     setShowingEnlargedImage(true)
-  }, [])
+  }, [closeLastModal, openModal, src])
 
   const keydownHandler = useMemo(() => {
     return (event: KeyboardEvent) => {
@@ -32,107 +39,34 @@ const ExpandableImage = ({ src }: ExpandableImageProps) => {
         showingEnlargedImage
       ) {
         preventKeyboardEventPropagation(event)
-        setShowingEnlargedImage(false)
+        closeLastModal()
       }
     }
-  }, [showingEnlargedImage])
+  }, [closeLastModal, showingEnlargedImage])
   useGlobalKeyDownHandler(keydownHandler)
 
   return (
-    <Container>
-      <ImageContainer
-        onClick={() => onImageExpand()}
-        onMouseOver={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
-        <Image src={src} />
+    <ImageContainer
+      onClick={() => onImageExpand()}
+      onMouseOver={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Image src={src} />
 
-        {isHovered && (
-          <>
-            <ImageActionButton
-              onClick={() => {
-                onImageExpand()
-              }}
-            >
-              <Icon path={mdiArrowExpandAll} />
-            </ImageActionButton>
-          </>
-        )}
-      </ImageContainer>
-
-      {showingEnlargedImage && (
-        <FullImageContainer>
-          <EnlargedImageContainer>
-            <ImageOptionsContainer>
-              <Button
-                className={'enlarged--image--btn-style'}
-                onClick={() => {
-                  setShowingEnlargedImage(false)
-                }}
-                variant={'transparent'}
-                iconPath={mdiClose}
-              />
-            </ImageOptionsContainer>
-            <Image src={src} />
-          </EnlargedImageContainer>
-          {showingEnlargedImage && (
-            <DimBackground onClick={() => setShowingEnlargedImage(false)} />
-          )}
-        </FullImageContainer>
+      {isHovered && (
+        <>
+          <ImageActionButton
+            onClick={() => {
+              onImageExpand()
+            }}
+          >
+            <Icon path={mdiArrowExpandAll} />
+          </ImageActionButton>
+        </>
       )}
-    </Container>
+    </ImageContainer>
   )
 }
-
-const EnlargedImageContainer = styled.span`
-  position: relative;
-  display: block;
-  z-index: 9000;
-
-  margin-left: 10%;
-  margin-right: 10%;
-`
-
-const ImageOptionsContainer = styled.span`
-  position: relative;
-  display: block;
-  .enlarged--image--btn-style {
-    position: absolute;
-    top: 0;
-    right: 0;
-    height: 30px;
-    width: 30px;
-    box-sizing: border-box;
-    font-size: 18px;
-    outline: none;
-
-    margin-right: -2em;
-    margin-bottom: -1em;
-  }
-`
-
-const FullImageContainer = styled.span`
-  position: fixed;
-  z-index: 9000;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`
-
-const DimBackground = styled.span`
-  position: absolute;
-  z-index: 6001;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.85);
-`
 
 const ImageContainer = styled.span`
   position: relative;
@@ -167,7 +101,5 @@ const ImageActionButton = styled.button`
     color: ${({ theme }) => theme.colors.text.subtle};
   }
 `
-
-const Container = styled.span``
 
 export default ExpandableImage

--- a/src/shared/components/molecules/Image/ExpandableImage.tsx
+++ b/src/shared/components/molecules/Image/ExpandableImage.tsx
@@ -75,23 +75,27 @@ const ExpandableImage = ({ src }: ExpandableImageProps) => {
             </ImageOptionsContainer>
             <Image src={src} />
           </EnlargedImageContainer>
-          {showingEnlargedImage && <DimBackground />}
+          {showingEnlargedImage && (
+            <DimBackground onClick={() => setShowingEnlargedImage(false)} />
+          )}
         </FullImageContainer>
       )}
     </Container>
   )
 }
 
-const EnlargedImageContainer = styled.div`
+const EnlargedImageContainer = styled.span`
   position: relative;
+  display: block;
   z-index: 9000;
 
   margin-left: 10%;
   margin-right: 10%;
 `
 
-const ImageOptionsContainer = styled.div`
+const ImageOptionsContainer = styled.span`
   position: relative;
+  display: block;
   .enlarged--image--btn-style {
     position: absolute;
     top: 0;
@@ -107,7 +111,7 @@ const ImageOptionsContainer = styled.div`
   }
 `
 
-const FullImageContainer = styled.div`
+const FullImageContainer = styled.span`
   position: fixed;
   z-index: 9000;
   top: 0;
@@ -120,7 +124,7 @@ const FullImageContainer = styled.div`
   align-items: center;
 `
 
-const DimBackground = styled.div`
+const DimBackground = styled.span`
   position: absolute;
   z-index: 6001;
   top: 0;
@@ -130,9 +134,10 @@ const DimBackground = styled.div`
   background-color: rgba(0, 0, 0, 0.85);
 `
 
-const ImageContainer = styled.div`
+const ImageContainer = styled.span`
   position: relative;
   cursor: pointer;
+  display: block;
 `
 
 const ImageActionButton = styled.button`
@@ -163,6 +168,6 @@ const ImageActionButton = styled.button`
   }
 `
 
-const Container = styled.div``
+const Container = styled.span``
 
 export default ExpandableImage

--- a/src/shared/components/molecules/Image/ExpandableImage.tsx
+++ b/src/shared/components/molecules/Image/ExpandableImage.tsx
@@ -1,0 +1,168 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import styled from '../../../lib/styled'
+import Image from '../../../../components/atoms/Image'
+import { mdiArrowExpandAll, mdiClose } from '@mdi/js'
+import Icon from '../../atoms/Icon'
+import { flexCenter } from '../../../lib/styled/styleFunctions'
+import {
+  isSingleKeyEventOutsideOfInput,
+  preventKeyboardEventPropagation,
+  useGlobalKeyDownHandler,
+} from '../../../../cloud/lib/keyboard'
+import Button from '../../atoms/Button'
+
+interface ExpandableImageProps {
+  src: string
+}
+
+const ExpandableImage = ({ src }: ExpandableImageProps) => {
+  const [isHovered, setIsHovered] = useState<boolean>(false)
+  const [showingEnlargedImage, setShowingEnlargedImage] = useState<boolean>(
+    false
+  )
+
+  const onImageExpand = useCallback(() => {
+    setShowingEnlargedImage(true)
+  }, [])
+
+  const keydownHandler = useMemo(() => {
+    return (event: KeyboardEvent) => {
+      if (
+        isSingleKeyEventOutsideOfInput(event, 'escape') &&
+        showingEnlargedImage
+      ) {
+        preventKeyboardEventPropagation(event)
+        setShowingEnlargedImage(false)
+      }
+    }
+  }, [showingEnlargedImage])
+  useGlobalKeyDownHandler(keydownHandler)
+
+  return (
+    <Container>
+      <ImageContainer
+        onClick={() => onImageExpand()}
+        onMouseOver={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <Image src={src} />
+
+        {isHovered && (
+          <>
+            <ImageActionButton
+              onClick={() => {
+                onImageExpand()
+              }}
+            >
+              <Icon path={mdiArrowExpandAll} />
+            </ImageActionButton>
+          </>
+        )}
+      </ImageContainer>
+
+      {showingEnlargedImage && (
+        <FullImageContainer>
+          <EnlargedImageContainer>
+            <ImageOptionsContainer>
+              <Button
+                className={'enlarged--image--btn-style'}
+                onClick={() => {
+                  setShowingEnlargedImage(false)
+                }}
+                variant={'transparent'}
+                iconPath={mdiClose}
+              />
+            </ImageOptionsContainer>
+            <Image src={src} />
+          </EnlargedImageContainer>
+          {showingEnlargedImage && <DimBackground />}
+        </FullImageContainer>
+      )}
+    </Container>
+  )
+}
+
+const EnlargedImageContainer = styled.div`
+  position: relative;
+  z-index: 9000;
+
+  margin-left: 10%;
+  margin-right: 10%;
+`
+
+const ImageOptionsContainer = styled.div`
+  position: relative;
+  .enlarged--image--btn-style {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 30px;
+    width: 30px;
+    box-sizing: border-box;
+    font-size: 18px;
+    outline: none;
+
+    margin-right: -2em;
+    margin-bottom: -1em;
+  }
+`
+
+const FullImageContainer = styled.div`
+  position: fixed;
+  z-index: 9000;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const DimBackground = styled.div`
+  position: absolute;
+  z-index: 6001;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.85);
+`
+
+const ImageContainer = styled.div`
+  position: relative;
+  cursor: pointer;
+`
+
+const ImageActionButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 30px;
+  width: 30px;
+  box-sizing: border-box;
+  font-size: 18px;
+  outline: none;
+
+  background-color: rgba(0, 0, 0, 0.3);
+  ${flexCenter};
+
+  border: none;
+  cursor: pointer;
+
+  transition: color 200ms ease-in-out;
+  color: ${({ theme }) => theme.colors.text.primary};
+  &:hover {
+    color: ${({ theme }) => theme.colors.text.link};
+  }
+
+  &:active,
+  &.active {
+    color: ${({ theme }) => theme.colors.text.subtle};
+  }
+`
+
+const Container = styled.div``
+
+export default ExpandableImage

--- a/src/shared/components/molecules/Image/ImagePreview.tsx
+++ b/src/shared/components/molecules/Image/ImagePreview.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import styled from '../../../lib/styled'
+import Image from '../../../../components/atoms/Image'
+
+interface ImagePreviewProps {
+  src: string
+}
+
+const ImagePreview = ({ src }: ImagePreviewProps) => {
+  return (
+    <Container>
+      <Image className={'image__preview_width'} src={src} />
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  padding: 1em 10%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  .image__preview_width {
+    max-width: 100%;
+  }
+`
+
+export default ImagePreview

--- a/src/shared/components/organisms/Modal/index.tsx
+++ b/src/shared/components/organisms/Modal/index.tsx
@@ -292,6 +292,10 @@ const Container = styled.div`
     &.modal__window__width--large {
       width: 1100px;
     }
+
+    &.modal__window__width--full {
+      width: 100%;
+    }
   }
 
   .modal__window__close {

--- a/src/shared/lib/stores/modal/types.ts
+++ b/src/shared/lib/stores/modal/types.ts
@@ -2,7 +2,7 @@ export interface ModalElement {
   title?: React.ReactNode
   content: React.ReactNode
   showCloseIcon?: boolean
-  width: 'large' | 'default' | 'small' | number
+  width: 'large' | 'default' | 'small' | 'full' | number
   height?: number
   maxHeight?: number
   position?: {
@@ -21,7 +21,7 @@ export type ContextModalAlignment = 'bottom-left' | 'bottom-right' | 'top-left'
 export type ModalOpeningOptions = {
   showCloseIcon?: boolean
   keepAll?: boolean
-  width?: 'large' | 'default' | 'small' | number
+  width?: 'large' | 'default' | 'small' | 'full' | number
   title?: string
   onClose?: () => void
 }


### PR DESCRIPTION
It is also a feature in WebApp but we can remove it from there if needed only in Desktop App.

Usage instructions:

Click on preview image to enlarge it
Click on enlarge button which activates on image hover to enlarge it
Click Escape once in enlarged view to discard it (close)
Click on Close button next to image in top right corner to close the view


Short preview how it works:
https://user-images.githubusercontent.com/18196945/128878278-8c6b770b-e404-486d-a443-b81bb9558bea.mp4


