### PR TITLE
Implement custom font settings

### DIFF
--- a/src/cloud/components/molecules/Editor/EditorAdmonitionToolDropdown.tsx
+++ b/src/cloud/components/molecules/Editor/EditorAdmonitionToolDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { useEffectOnce } from 'react-use'
 import { getFirstFocusableChildOfElement } from '../../../lib/dom'
 import { FormattingTool } from './types'
@@ -34,7 +34,7 @@ const EditorAdmonitionToolDropdown = ({
   closeDropdowndown,
   onFormatCallback,
 }: EditorAdmonitionToolDropdownProps) => {
-  const menuRef = React.createRef<HTMLDivElement>()
+  const menuRef = useRef<HTMLDivElement>(null)
 
   useEffectOnce(() => {
     const focusableElement = getFirstFocusableChildOfElement(menuRef.current!)

--- a/src/cloud/components/molecules/Editor/EditorHeaderToolDropdown.tsx
+++ b/src/cloud/components/molecules/Editor/EditorHeaderToolDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { useEffectOnce } from 'react-use'
 import { getFirstFocusableChildOfElement } from '../../../lib/dom'
 import { FormattingTool } from './types'
@@ -45,7 +45,7 @@ const EditorHeaderToolDropdown = ({
   closeDropdowndown,
   onFormatCallback,
 }: EditorHeaderToolDropdownProps) => {
-  const menuRef = React.createRef<HTMLDivElement>()
+  const menuRef = useRef<HTMLDivElement>(null)
 
   useEffectOnce(() => {
     const focusableElement = getFirstFocusableChildOfElement(menuRef.current!)

--- a/src/cloud/components/molecules/Editor/index.tsx
+++ b/src/cloud/components/molecules/Editor/index.tsx
@@ -597,12 +597,9 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
   )
 
   const { settings } = useSettings()
-  const fontSize = useMemo(() => {
-    return settings['general.editorFontSize']
-  }, [settings])
-  const fontFamily = useMemo(() => {
-    return settings['general.editorFontFamily']
-  }, [settings])
+  const fontSize = settings['general.editorFontSize']
+  const fontFamily = settings['general.editorFontFamily']
+
   const editorConfig: CodeMirror.EditorConfiguration = useMemo(() => {
     const editorTheme = settings['general.editorTheme']
     const theme =

--- a/src/cloud/components/molecules/Editor/index.tsx
+++ b/src/cloud/components/molecules/Editor/index.tsx
@@ -95,6 +95,7 @@ import DocShare from '../DocShare'
 import EditorLayout from '../../organisms/EditorLayout'
 import PreferencesContextMenuWrapper from '../../molecules/PreferencesContextMenuWrapper'
 import InviteCTAButton from '../InviteCTAButton'
+import { BaseTheme } from '../../../../shared/lib/styled/types'
 
 type LayoutMode = 'split' | 'preview' | 'editor'
 
@@ -596,6 +597,12 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
   )
 
   const { settings } = useSettings()
+  const fontSize = useMemo(() => {
+    return settings['general.editorFontSize']
+  }, [settings])
+  const fontFamily = useMemo(() => {
+    return settings['general.editorFontFamily']
+  }, [settings])
   const editorConfig: CodeMirror.EditorConfiguration = useMemo(() => {
     const editorTheme = settings['general.editorTheme']
     const theme =
@@ -1077,7 +1084,11 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
             </StyledLayoutDimensions>
           )}
           <StyledEditor className={editorLayout}>
-            <StyledEditorWrapper className={`layout-${editorLayout}`}>
+            <StyledEditorWrapper
+              className={`layout-${editorLayout}`}
+              fontFamily={fontFamily}
+              fontSize={fontSize}
+            >
               <>
                 <CodeMirrorEditor
                   bind={bindCallback}
@@ -1241,8 +1252,11 @@ const ToolbarRow = styled.div`
   border: solid 1px ${({ theme }) => theme.divideBorderColor};
   border-radius: 5px;
 `
-
-const StyledEditorWrapper = styled.div`
+interface FontOptionsProps {
+  fontSize: string
+  fontFamily: string
+}
+const StyledEditorWrapper = styled.div<BaseTheme & FontOptionsProps>`
   position: relative;
   height: auto;
   width: 50%;
@@ -1251,6 +1265,13 @@ const StyledEditorWrapper = styled.div`
   }
   &.layout-preview {
     display: none;
+  }
+
+  & .CodeMirror * {
+    font-size: ${({ fontSize }) =>
+      fontSize == null ? 'inherit' : `${fontSize}px`};
+    font-family: ${({ fontFamily }) =>
+      fontFamily == null ? 'monospace' : fontFamily};
   }
 `
 

--- a/src/cloud/components/molecules/RelativeDialog/RelativeDialog.tsx
+++ b/src/cloud/components/molecules/RelativeDialog/RelativeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import {
   StyledRelativeDialog,
   StyledWrapper,
@@ -17,7 +17,7 @@ const RelativeDialog = ({
   closed,
   setClosed,
 }: React.PropsWithChildren<RelativeDialogProps>) => {
-  const dialogRef: React.RefObject<HTMLDivElement> = React.createRef()
+  const dialogRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!closed) {

--- a/src/cloud/components/molecules/Timeline/TimelineList.tsx
+++ b/src/cloud/components/molecules/Timeline/TimelineList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { SerializedAppEvent } from '../../../interfaces/db/appEvents'
 import { useNav } from '../../../lib/stores/nav'
 import { getOriginalDocId } from '../../../lib/utils/patterns'
@@ -28,7 +28,7 @@ const TimelineList = ({
   workspacesMap,
 }: TimelineListProps) => {
   const { docsMap } = useNav()
-  const listRef = React.createRef<HTMLDivElement>()
+  const listRef = useRef<HTMLDivElement>(null)
   useUpDownNavigationListener(listRef)
 
   const timelineDocs = useMemo(() => {

--- a/src/cloud/components/organisms/EventSource.tsx
+++ b/src/cloud/components/organisms/EventSource.tsx
@@ -193,7 +193,7 @@ const EventSource = ({ teamId }: EventSourceProps) => {
       }
 
       if (usingElectron) {
-        sendToElectron('team-update', event.data.team)
+        sendToElectron('team-update', { ...team, ...eventTeam })
       }
     },
     [

--- a/src/cloud/components/organisms/ImportFlow/molecules/ImportFlowDestination.tsx
+++ b/src/cloud/components/organisms/ImportFlow/molecules/ImportFlowDestination.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { useNav } from '../../../../lib/stores/nav'
 import { sortByAttributeAsc } from '../../../../lib/utils/array'
 import { SerializedWorkspace } from '../../../../interfaces/db/workspace'
@@ -28,7 +28,7 @@ const ImportModalSelectFolder = ({
   onSelect,
 }: ImportModalSelectFolderProps) => {
   const { foldersMap, workspacesMap } = useNav()
-  const wrapperRef = React.createRef<HTMLDivElement>()
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const { translate } = useI18n()
 
   const sortedWorkspaces = useMemo(() => {

--- a/src/cloud/components/organisms/Modal/contents/TemplatesModal/index.tsx
+++ b/src/cloud/components/organisms/Modal/contents/TemplatesModal/index.tsx
@@ -67,8 +67,8 @@ const TemplatesModal = ({ callback }: TemplatesModalProps) => {
     currentParentFolderId,
   } = useNav()
   const { pushApiErrorMessage } = useToast()
-  const contentSideRef = React.createRef<HTMLDivElement>()
-  const menuRef = React.createRef<HTMLDivElement>()
+  const contentSideRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const [filter, setFilter] = useState<string>('')
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>()
   const [templateTitle, setTemplateTitle] = useState<string>('')

--- a/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/FolderContextMenu.tsx
+++ b/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/FolderContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef } from 'react'
 import { usePage } from '../../../../../lib/stores/pageStore'
 import { useNav } from '../../../../../lib/stores/nav'
 import {
@@ -48,7 +48,7 @@ const FolderContextMenu = ({
   const { openRenameFolderForm } = useCloudResourceModals()
   const { translate } = useI18n()
 
-  const menuRef = React.createRef<HTMLDivElement>()
+  const menuRef = useRef<HTMLDivElement>(null)
   useEffectOnce(() => {
     menuRef.current!.focus()
   })

--- a/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/TagContextMenu.tsx
+++ b/src/cloud/components/organisms/Topbar/Controls/ControlsContextMenu/TagContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react'
+import React, { useState, useMemo, useCallback, useRef } from 'react'
 import { usePage } from '../../../../../lib/stores/pageStore'
 import { useNav } from '../../../../../lib/stores/nav'
 import ContextMenuItem from './ControlsContextMenuItem'
@@ -46,7 +46,7 @@ const TagContextMenu = ({
   const { pushApiErrorMessage } = useToast()
   const { messageBox } = useDialog()
 
-  const menuRef = React.createRef<HTMLDivElement>()
+  const menuRef = useRef<HTMLDivElement>(null)
   useEffectOnce(() => {
     menuRef.current!.focus()
   })

--- a/src/cloud/components/organisms/settings/SettingsComponent.tsx
+++ b/src/cloud/components/organisms/settings/SettingsComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react'
+import React, { useMemo, useEffect, useRef } from 'react'
 import { useSettings } from '../../../lib/stores/settings'
 import {
   preventKeyboardEventPropagation,
@@ -57,8 +57,8 @@ const SettingsComponent = () => {
     openSettingsTab,
     settingsOpeningOptions,
   } = useSettings()
-  const contentSideRef = React.createRef<HTMLDivElement>()
-  const menuRef = React.createRef<HTMLDivElement>()
+  const contentSideRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const { team, subscription, currentUserPermissions } = usePage<
     PageStoreWithTeam
   >()

--- a/src/cloud/components/organisms/settings/UserPreferencesForm.tsx
+++ b/src/cloud/components/organisms/settings/UserPreferencesForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { ChangeEventHandler, useCallback, useState } from 'react'
 import {
   useSettings,
   GeneralThemeOptions,
@@ -19,10 +19,18 @@ import FormSelect, {
 } from '../../../../shared/components/molecules/Form/atoms/FormSelect'
 import FormRow from '../../../../shared/components/molecules/Form/templates/FormRow'
 import { lngKeys } from '../../../lib/i18n/types'
+import { useDebounce } from 'react-use'
 
 const UserPreferencesForm = () => {
   const { settings, setSettings } = useSettings()
   const { t } = useTranslation()
+
+  const [fontSize, setFontSize] = useState(
+    settings['general.editorFontSize'].toString()
+  )
+  const [fontFamily, setFontFamily] = useState(
+    settings['general.editorFontFamily']
+  )
 
   const selectLanguage = useCallback(
     (formOption: FormSelectOption) => {
@@ -100,6 +108,41 @@ const UserPreferencesForm = () => {
     [setSettings]
   )
 
+  const updateFontSize: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      setFontSize(event.target.value)
+    },
+    [setFontSize]
+  )
+  useDebounce(
+    () => {
+      const parsedFontSize = parseInt(fontSize, 10)
+      if (!Number.isNaN(parsedFontSize)) {
+        setSettings({
+          'general.editorFontSize': parsedFontSize,
+        })
+      }
+    },
+    500,
+    [fontSize, setSettings]
+  )
+
+  const updateFontFamily: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      setFontFamily(event.target.value)
+    },
+    [setFontFamily]
+  )
+  useDebounce(
+    () => {
+      setSettings({
+        'general.editorFontFamily': fontFamily,
+      })
+    },
+    500,
+    [fontFamily, setSettings]
+  )
+
   return (
     <Form
       rows={[
@@ -159,6 +202,32 @@ const UserPreferencesForm = () => {
                   onChange={selectTheme}
                 />
               ),
+            },
+          ],
+        },
+        {
+          title: t(lngKeys.SettingsEditorFontSize),
+          items: [
+            {
+              type: 'input',
+              props: {
+                type: 'number',
+                value: fontSize,
+                onChange: updateFontSize,
+              },
+            },
+          ],
+        },
+        {
+          title: t(lngKeys.SettingsEditorFontFamily),
+          items: [
+            {
+              type: 'input',
+              props: {
+                type: 'text',
+                value: fontFamily,
+                onChange: updateFontFamily,
+              },
             },
           ],
         },

--- a/src/cloud/lib/i18n/enUS.ts
+++ b/src/cloud/lib/i18n/enUS.ts
@@ -50,6 +50,8 @@ const enTranslation: TranslationSource = {
   [lngKeys.SettingsEditorTheme]: 'Editor Theme',
   [lngKeys.SettingsCodeBlockTheme]: 'Code Block Theme',
   [lngKeys.SettingsEditorKeyMap]: 'Editor Keymap',
+  [lngKeys.SettingsEditorFontSize]: 'Editor Font Size',
+  [lngKeys.SettingsEditorFontFamily]: 'Editor Font Family',
   [lngKeys.SettingsLight]: 'Light',
   [lngKeys.SettingsDark]: 'Dark',
   [lngKeys.SettingsNotifFrequencies]: 'Email updates',

--- a/src/cloud/lib/i18n/fr.ts
+++ b/src/cloud/lib/i18n/fr.ts
@@ -51,6 +51,8 @@ const frTranslation: TranslationSource = {
   [lngKeys.SettingsEditorTheme]: "Thème de l'éditeur",
   [lngKeys.SettingsCodeBlockTheme]: 'Thème des blocs de code',
   [lngKeys.SettingsEditorKeyMap]: "KeyMap pour l'éditeur",
+  [lngKeys.SettingsEditorFontSize]: "Taille de la police de l'éditeur",
+  [lngKeys.SettingsEditorFontFamily]: "Famille de polices de l'éditeur",
   [lngKeys.SettingsLight]: 'Clair',
   [lngKeys.SettingsDark]: 'Sombre',
   [lngKeys.SettingsNotifFrequencies]: 'Fréquence de mises à jour par mail',

--- a/src/cloud/lib/i18n/ja.ts
+++ b/src/cloud/lib/i18n/ja.ts
@@ -50,6 +50,8 @@ const jpTranslation: TranslationSource = {
   [lngKeys.SettingsEditorTheme]: 'エディタテーマ',
   [lngKeys.SettingsCodeBlockTheme]: 'コードブロックテーマ',
   [lngKeys.SettingsEditorKeyMap]: 'エディタのキーマップ',
+  [lngKeys.SettingsEditorFontSize]: 'エディタのフォントサイズ',
+  [lngKeys.SettingsEditorFontFamily]: 'エディタフォントファミリ',
   [lngKeys.SettingsLight]: 'ライト',
   [lngKeys.SettingsDark]: 'ダーク',
   [lngKeys.SettingsNotifFrequencies]: 'メール設定',

--- a/src/cloud/lib/i18n/types.ts
+++ b/src/cloud/lib/i18n/types.ts
@@ -120,6 +120,8 @@ export enum lngKeys {
   SettingsEditorTheme = 'settings.editorTheme',
   SettingsCodeBlockTheme = 'settings.codeblockTheme',
   SettingsEditorKeyMap = 'settings.editorKeyMap',
+  SettingsEditorFontSize = 'settings.editorFontSize',
+  SettingsEditorFontFamily = 'settings.editorFontFamily',
   SettingsLight = 'settings.light',
   SettingsDark = 'settings.dark',
   SettingsNotifFrequencies = 'settings.notificationsFrequency',

--- a/src/cloud/lib/i18n/zhCN.ts
+++ b/src/cloud/lib/i18n/zhCN.ts
@@ -50,6 +50,8 @@ const zhTranslation: TranslationSource = {
   [lngKeys.SettingsEditorTheme]: '编辑主题',
   [lngKeys.SettingsCodeBlockTheme]: '代码块主题',
   [lngKeys.SettingsEditorKeyMap]: '编辑器键映射',
+  [lngKeys.SettingsEditorFontSize]: '编辑器字体大小',
+  [lngKeys.SettingsEditorFontFamily]: '编辑器字体系列',
   [lngKeys.SettingsLight]: 'Light',
   [lngKeys.SettingsDark]: 'Dark',
   [lngKeys.SettingsNotifFrequencies]: 'Email updates',

--- a/src/cloud/lib/stores/settings/store.ts
+++ b/src/cloud/lib/stores/settings/store.ts
@@ -22,6 +22,9 @@ export const baseUserSettings: UserSettings = {
   'general.editorKeyMap': 'default',
   'general.editorIndentType': 'spaces',
   'general.editorIndentSize': 2,
+  'general.editorFontSize': 15,
+  'general.editorFontFamily':
+    'SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace',
 }
 
 export type SettingsTab =

--- a/src/cloud/lib/stores/settings/types.ts
+++ b/src/cloud/lib/stores/settings/types.ts
@@ -13,6 +13,8 @@ export interface UserSettings {
   'general.editorKeyMap': CodeMirrorKeyMap
   'general.editorIndentType': GeneralEditorIndentType
   'general.editorIndentSize': GeneralEditorIndentSize
+  'general.editorFontSize': number
+  'general.editorFontFamily': string
 }
 
 export const codeMirrorEditorThemes = [

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -211,6 +211,9 @@ const App = () => {
 
     const boostHubTeamUpdateEventHandler = (event: BoostHubTeamUpdateEvent) => {
       const updatedTeam = event.detail.team
+      if (updatedTeam.id == null) {
+        return
+      }
       setGeneralStatus((previousGeneralStatus) => {
         const teamMap =
           previousGeneralStatus.boostHubTeams!.reduce((map, team) => {

--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -46,6 +46,7 @@ import { useModal } from '../../../shared/lib/stores/modal'
 import DocInfoModal from '../organisms/modals/DocInfoModal'
 import { SerializedRevision } from '../../../cloud/interfaces/db/revision'
 import { osName } from '../../../lib/platform'
+import { BaseTheme } from '../../../shared/lib/styled/types'
 
 interface EditorProps {
   doc: SerializedDocWithBookmark
@@ -319,6 +320,12 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
   }, [editorMode])
 
   const { settings } = useSettings()
+  const fontSize = useMemo(() => {
+    return settings['general.editorFontSize']
+  }, [settings])
+  const fontFamily = useMemo(() => {
+    return settings['general.editorFontFamily']
+  }, [settings])
   const editorConfig: CodeMirror.EditorConfiguration = useMemo(() => {
     const editorTheme = settings['general.editorTheme']
     const theme =
@@ -502,7 +509,11 @@ const Editor = ({ doc, team, user, contributors, backLinks }: EditorProps) => {
     >
       <Container>
         <StyledEditor className={editorMode}>
-          <StyledEditorWrapper className={`layout-${editorMode}`}>
+          <StyledEditorWrapper
+            className={`layout-${editorMode}`}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+          >
             <>
               <CodeMirrorEditor
                 bind={bindCallback}
@@ -615,7 +626,12 @@ const StyledLoadingView = styled.div`
   }
 `
 
-const StyledEditorWrapper = styled.div`
+interface FontOptionsProps {
+  fontSize: string
+  fontFamily: string
+}
+
+const StyledEditorWrapper = styled.div<BaseTheme & FontOptionsProps>`
   position: relative;
   height: auto;
   &.layout-edit {
@@ -623,6 +639,13 @@ const StyledEditorWrapper = styled.div`
   }
   &.layout-preview {
     display: none;
+  }
+
+  & .CodeMirror * {
+    font-size: ${({ fontSize }) =>
+      fontSize == null ? 'inherit' : `${fontSize}px`};
+    font-family: ${({ fontFamily }) =>
+      fontFamily == null ? 'monospace' : fontFamily};
   }
 `
 

--- a/src/shared/components/atoms/LeftRightList.tsx
+++ b/src/shared/components/atoms/LeftRightList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useEffectOnce } from 'react-use'
 import { useLeftToRightNavigationListener } from '../../lib/keyboard'
 
@@ -9,7 +9,7 @@ const LeftToRightList: React.FC<LeftToRightListProps> = ({
   className,
   children,
 }) => {
-  const listRef = React.createRef<HTMLDivElement>()
+  const listRef = useRef<HTMLDivElement>(null)
   useEffectOnce(() => {
     if (listRef.current != null) {
       listRef.current.focus()

--- a/src/shared/components/atoms/UpDownList.tsx
+++ b/src/shared/components/atoms/UpDownList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useEffectOnce } from 'react-use'
 import { focusFirstChildFromElement } from '../../lib/dom'
 import { useUpDownNavigationListener } from '../../lib/keyboard'
@@ -14,7 +14,7 @@ const UpDownList: React.FC<UpDownListProps> = ({
   ignoreFocus,
   onBlur,
 }) => {
-  const listRef = React.createRef<HTMLDivElement>()
+  const listRef = useRef<HTMLDivElement>(null)
 
   const onBlurHandler = (event: any) => {
     if (onBlur == null) {

--- a/src/shared/components/molecules/EmojiPicker.tsx
+++ b/src/shared/components/molecules/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { Picker, EmojiData } from 'emoji-mart'
 import styled from '../../lib/styled'
 import Button from '../atoms/Button'
@@ -13,7 +13,7 @@ import {
 
 const EmojiPicker = () => {
   const { closed, closeEmojiPicker, position, callback } = useEmoji()
-  const pickerRef: React.RefObject<HTMLDivElement> = React.createRef()
+  const pickerRef = useRef<HTMLDivElement>(null)
   const { windowSize } = useWindow()
   const { pushApiErrorMessage } = useToast()
 

--- a/src/shared/components/organisms/Sidebar/atoms/SidebarContextList.tsx
+++ b/src/shared/components/organisms/Sidebar/atoms/SidebarContextList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { useEffectOnce } from 'react-use'
 import { focusFirstChildFromElement } from '../../../../lib/dom'
 import {
@@ -18,7 +18,7 @@ const SidebarContextList: AppComponent<SidebarContextListProps> = ({
   children,
   onBlur,
 }) => {
-  const listRef = React.createRef<HTMLDivElement>()
+  const listRef = useRef<HTMLDivElement>(null)
   useEffectOnce(() => {
     if (listRef.current != null) {
       listRef.current.focus()

--- a/src/shared/components/templates/ContentLayout.tsx
+++ b/src/shared/components/templates/ContentLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef } from 'react'
 import styled from '../../lib/styled'
 import { AppComponent } from '../../lib/types'
 import DoublePane from '../atoms/DoublePane'
@@ -28,7 +28,7 @@ const ContentLayout: AppComponent<ContentLayoutProps> = ({
   reduced,
   header,
 }) => {
-  const rightSideContentRef = React.createRef<HTMLDivElement>()
+  const rightSideContentRef = useRef<HTMLDivElement>(null)
   const keydownHandler = useCallback(
     async (event: KeyboardEvent) => {
       if (isFocusRightSideShortcut(event)) {


### PR DESCRIPTION
Add font size and family to Account Preferences
Add translations keys and translations for all supported languages for new Settings
Update mobile and desktop app code mirror editor to respect font size and font families

Tested in desktop app
- Changing font works
- Changing font family works
- Changing languages shows correct preferences descriptions

- Changing font family loses focus after update (not sure why it happens here and not in local space)