### PR TITLE
Refactor Drag and Drop and implement sidenav and folder view dragging

### DIFF
--- a/src/cloud/components/molecules/ContentManager/Rows/ContentManagerDocRow.tsx
+++ b/src/cloud/components/molecules/ContentManager/Rows/ContentManagerDocRow.tsx
@@ -33,6 +33,9 @@ interface ContentManagerDocRowProps {
   currentUserIsCoreMember: boolean
   onSelect: (val: boolean) => void
   setUpdating: React.Dispatch<React.SetStateAction<string[]>>
+  onDragStart: (event: any, doc: SerializedDocWithBookmark) => void
+  onDragEnd: (event: any) => void
+  onDrop: (event: any, doc: SerializedDocWithBookmark) => void
 }
 
 const ContentManagerDocRow = ({
@@ -43,6 +46,9 @@ const ContentManagerDocRow = ({
   showPath,
   currentUserIsCoreMember,
   onSelect,
+  onDragStart,
+  onDragEnd,
+  onDrop,
 }: ContentManagerDocRowProps) => {
   const { permissions = [] } = usePage()
   const { push } = useRouter()
@@ -165,6 +171,9 @@ const ContentManagerDocRow = ({
       labelOnclick={() => push(href)}
       defaultIcon={mdiFileDocumentOutline}
       emoji={doc.emoji}
+      onDragStart={(event: any) => onDragStart(event, doc)}
+      onDragEnd={(event: any) => onDragEnd(event)}
+      onDrop={(event: any) => onDrop(event, doc)}
     >
       <ContentManagerCell fullWidth={true}>
         <DocAssigneeSelect

--- a/src/cloud/components/molecules/ContentManager/Rows/ContentManagerFolderRow.tsx
+++ b/src/cloud/components/molecules/ContentManager/Rows/ContentManagerFolderRow.tsx
@@ -8,6 +8,7 @@ import { useNav } from '../../../../lib/stores/nav'
 import { useTranslation } from 'react-i18next'
 import { lngKeys } from '../../../../lib/i18n/types'
 import { useRouter } from '../../../../lib/router'
+
 interface ContentManagerFolderRowProps {
   team: SerializedTeam
   folder: SerializedFolderWithBookmark
@@ -16,6 +17,9 @@ interface ContentManagerFolderRowProps {
   checked?: boolean
   onSelect: (val: boolean) => void
   currentUserIsCoreMember: boolean
+  onDragStart: (event: any, folder: SerializedFolderWithBookmark) => void
+  onDragEnd: (event: any) => void
+  onDrop: (event: any, folder: SerializedFolderWithBookmark) => void
 }
 
 const ContentmanagerFolderRow = ({
@@ -24,6 +28,9 @@ const ContentmanagerFolderRow = ({
   checked,
   currentUserIsCoreMember,
   onSelect,
+  onDragStart,
+  onDragEnd,
+  onDrop,
 }: ContentManagerFolderRowProps) => {
   const { t } = useTranslation()
   const { docsMap, foldersMap } = useNav()
@@ -51,6 +58,9 @@ const ContentmanagerFolderRow = ({
       emoji={folder.emoji}
       labelHref={href}
       labelOnclick={() => push(href)}
+      onDragStart={(event: any) => onDragStart(event, folder)}
+      onDragEnd={(event: any) => onDragEnd(event)}
+      onDrop={(event: any) => onDrop(event, folder)}
     >
       <ContentManagerCell>
         {childrenFolders} {t(lngKeys.GeneralFolders).toLocaleLowerCase()}{' '}

--- a/src/cloud/interfaces/resources.ts
+++ b/src/cloud/interfaces/resources.ts
@@ -1,14 +1,36 @@
-import { SerializedFolderWithBookmark } from './db/folder'
-import { SerializedDocWithBookmark } from './db/doc'
+export const FOLDER_DRAG_TRANSFER_DATA_JSON =
+  'application/boostnote.folder+json'
+export const DOC_DRAG_TRANSFER_DATA_JSON = 'application/boostnote.doc+json'
+export const CATEGORY_DRAG_TRANSFER_DATA_JSON =
+  'application/boostnote.category+json'
+
+export interface DocDataTransferItem {
+  workspaceId: string
+  teamId: string
+  id: string
+  emoji?: string
+  url: string
+  title: string
+}
+
+export interface FolderDataTransferItem {
+  workspaceId: string
+  teamId: string
+  id: string
+  emoji?: string
+  url: string
+  name: string
+  description?: string
+}
 
 export type SerializedFolderNav = {
   type: 'folder'
-  result: SerializedFolderWithBookmark
+  resource: FolderDataTransferItem
 }
 
 export type SerializedDocNav = {
   type: 'doc'
-  result: SerializedDocWithBookmark
+  resource: DocDataTransferItem
 }
 
 export type SerializedPendingNav = {

--- a/src/cloud/lib/hooks/useCloudApi.ts
+++ b/src/cloud/lib/hooks/useCloudApi.ts
@@ -68,6 +68,10 @@ import { SerializedWorkspace } from '../../interfaces/db/workspace'
 import { deleteSmartFolder } from '../../api/teams/smart-folder'
 
 import { format as formatDate } from 'date-fns'
+import {
+  DocDataTransferItem,
+  FolderDataTransferItem,
+} from '../../interfaces/resources'
 
 export function useCloudApi() {
   const { pageDoc, pageFolder, setPartialPageData } = usePage()
@@ -271,7 +275,10 @@ export function useCloudApi() {
   )
 
   const updateFolderApi = useCallback(
-    async (target: SerializedFolder, body: UpdateFolderRequestBody) => {
+    async (
+      target: SerializedFolder | FolderDataTransferItem,
+      body: UpdateFolderRequestBody
+    ) => {
       await send(target.id, 'update', {
         api: () => updateFolder({ id: target.teamId }, target.id, body),
         cb: ({ folders, docs, workspaces }: UpdateFolderResponseBody) => {
@@ -312,7 +319,10 @@ export function useCloudApi() {
   )
 
   const updateDocApi = useCallback(
-    async (target: SerializedDoc, body: UpdateDocRequestBody) => {
+    async (
+      target: SerializedDoc | DocDataTransferItem,
+      body: UpdateDocRequestBody
+    ) => {
       await send(target.id, 'update', {
         api: () => updateDoc(target.teamId, target.id, body),
         cb: ({ folders, doc, workspaces }: UpdateDocResponseBody) => {

--- a/src/shared/components/organisms/Sidebar/molecules/SidebarTree.tsx
+++ b/src/shared/components/organisms/Sidebar/molecules/SidebarTree.tsx
@@ -3,7 +3,7 @@ import styled from '../../../../lib/styled'
 import cc from 'classcat'
 import { FoldingProps } from '../../../atoms/FoldingWrapper'
 import { ControlButtonProps } from '../../../../lib/types'
-import { MenuItem } from '../../../../lib/stores/contextMenu/types'
+import { MenuItem } from '../../../../lib/stores/contextMenu'
 import SidebarTreeForm from '../atoms/SidebarTreeForm'
 import { DraggedTo, onDragLeaveCb, SidebarDragState } from '../../../../lib/dnd'
 import SidebarItem from '../atoms/SidebarTreeItem'
@@ -34,9 +34,9 @@ export interface SidebarNavCategory {
   footer?: React.ReactNode
   lastCategory?: boolean
   drag?: {
-    onDragStart: () => void
-    onDragEnd: () => void
-    onDrop: () => void
+    onDragStart: (event: any) => void
+    onDragEnd: (event: any) => void
+    onDrop: (event: any) => void
   }
 }
 
@@ -59,9 +59,9 @@ interface SidebarNavRow {
   contextControls?: MenuItem[]
   dropIn?: boolean
   dropAround?: boolean
-  onDragStart?: () => void
-  onDrop?: (position?: SidebarDragState) => void
-  onDragEnd?: () => void
+  onDragStart?: (event: any) => void
+  onDrop?: (event: any, position?: SidebarDragState) => void
+  onDragEnd?: (event: any) => void
 }
 
 export type SidebarNavControls =
@@ -233,15 +233,15 @@ const SidebarCategory = ({
       onDragStart={(event) => {
         event.stopPropagation()
         setDraggingCategory(true)
-        category.drag!.onDragStart()
+        category.drag!.onDragStart(event)
       }}
       onDragLeave={(event) => {
         onDragLeaveCb(event, dragRef, () => {
           setDraggedOver(false)
         })
       }}
-      onDragEnd={() => {
-        category.drag!.onDragEnd()
+      onDragEnd={(event) => {
+        category.drag!.onDragEnd(event)
       }}
       onDragOver={(event) => {
         event.preventDefault()
@@ -250,7 +250,7 @@ const SidebarCategory = ({
       }}
       onDrop={(event) => {
         event.stopPropagation()
-        category.drag!.onDrop()
+        category.drag!.onDrop(event)
         setDraggedOver(false)
       }}
     >
@@ -312,7 +312,7 @@ const SidebarNestedTreeRow = ({
     (event: any) => {
       event.stopPropagation()
       if (row.onDragStart != null) {
-        row.onDragStart()
+        row.onDragStart(event)
       }
       setDraggingItem(true)
     },
@@ -323,7 +323,7 @@ const SidebarNestedTreeRow = ({
     (event: React.DragEvent, position: SidebarDragState) => {
       event.preventDefault()
       if (row.onDrop != null) {
-        row.onDrop(position)
+        row.onDrop(event, position)
       }
       setDraggedOver(undefined)
       setDraggingItem(false)
@@ -379,9 +379,9 @@ const SidebarNestedTreeRow = ({
             setDraggedOver(undefined)
           })
         }}
-        onDragEnd={() => {
+        onDragEnd={(event) => {
           if (row.onDragEnd != null) {
-            row.onDragEnd()
+            row.onDragEnd(event)
           }
         }}
         onDragOver={(event) => {


### PR DESCRIPTION
 Add dnd inside folder view and across sidenav and folder view

Add callbacks for dnd functions
Update lower level components to use dnd functions

Add initial dnd refactor

Replace dragged resource with resource saving in transfer data
Change APIs across codebase (dragStart, dragEnd, dropOn)
Add text/plain data transfer to folder and doc dragg save events

Drag and drop showcase:

https://user-images.githubusercontent.com/18196945/129209367-f6e27f3d-3cfe-44d0-9dd1-26b09e8ef716.mp4

Tested in desktop app
- Test dropping a folder inside another folder (all views, only folders view)
- Test dropping a note inside another folder
- Test dropping a note/folder from folder view to sidebar (works)

Current bug (I think already present before)
- Dropping in workspace/root folder gives already present but it is not 
- Dropping in lower level folders works