### PR TITLE
Fix wrong offset calculation for links

### DIFF
--- a/src/cloud/components/atoms/MarkdownView/index.tsx
+++ b/src/cloud/components/atoms/MarkdownView/index.tsx
@@ -437,7 +437,11 @@ function getSelectionContext(
 }
 
 function getOffset(node: Node) {
-  const nonTextNode = node.TEXT_NODE ? node.parentElement : node
+  const nonTextNode = node.TEXT_NODE
+    ? node.parentElement != null && node.parentElement.nodeName == 'A'
+      ? node.parentElement.parentElement
+      : node.parentElement
+    : node
   if (nonTextNode == null || !isElement(nonTextNode)) return null
   const offset = parseInt(nonTextNode.getAttribute('data-offset') || '', 10)
   return isNaN(offset) ? null : offset


### PR DESCRIPTION
The offset should be calculate from parents parent node not parent node of text segment selection

Tested in desktop app and webapp:
- Add comment on plain text
- Add comment on link
- Add comment on header link

Showcase test: 

https://user-images.githubusercontent.com/18196945/129226243-c58e1ed3-4008-4399-a644-d25a3ef09a53.mp4

