### PR TITLE
Add progress bars on move bulk items

### DIFF
--- a/src/cloud/components/molecules/ContentManager/ContentManagerToolbar.tsx
+++ b/src/cloud/components/molecules/ContentManager/ContentManagerToolbar.tsx
@@ -33,6 +33,7 @@ import DocStatusSelect from '../../organisms/DocProperties/DocStatusSelect'
 import ContentManagerToolbarStatusPopup from './ContentManagerToolbarStatusPopup'
 import DocAssigneeSelect from '../../organisms/DocProperties/DocAssigneeSelect'
 import DocLabelSelectionModal from '../../organisms/DocProperties/DocLabelSelectionModal'
+import BulkActionProgress from '../../../../shared/components/molecules/BulkActionProgress'
 
 interface ContentManagerToolbarProps {
   team: SerializedTeam
@@ -52,6 +53,11 @@ enum BulkActions {
   status = 3,
   assignees = 4,
   label = 5,
+}
+
+export interface BulkActionState {
+  jobCount: number
+  jobsCompleted: number
 }
 
 const ContentManagerToolbar = ({
@@ -77,6 +83,11 @@ const ContentManagerToolbar = ({
   const { translate } = useI18n()
   const { messageBox } = useDialog()
   const { openModal, openContextModal, closeAllModals } = useModal()
+
+  const [
+    bulkActionState,
+    setBulkActionState,
+  ] = useState<BulkActionState | null>(null)
 
   const selectedDocsAreUpdating = useMemo(() => {
     return (
@@ -136,12 +147,31 @@ const ContentManagerToolbar = ({
       )
       setUpdating((prev) => [...prev, ...patternedIds])
       setSending(BulkActions.move)
+
+      setBulkActionState(() => {
+        return {
+          jobCount: patternedIds.length,
+          jobsCompleted: 0,
+        }
+      })
       for (const folderId of selectedFolders.values()) {
         await moveSingleFolder(folderId, workspaceId, parentFolderId)
+        setBulkActionState((prev) => {
+          return {
+            jobCount: patternedIds.length,
+            jobsCompleted: prev === null ? 0 : prev.jobsCompleted + 1,
+          }
+        })
       }
 
       for (const docId of selectedDocs.values()) {
         await moveSingleDoc(docId, workspaceId, parentFolderId)
+        setBulkActionState((prev) => {
+          return {
+            jobCount: patternedIds.length,
+            jobsCompleted: prev === null ? 0 : prev.jobsCompleted + 1,
+          }
+        })
       }
       setSending(undefined)
       setUpdating((prev) => difference(prev, patternedIds))
@@ -411,96 +441,101 @@ const ContentManagerToolbar = ({
   }
 
   return (
-    <Container className='cm__toolbar'>
-      <div className='cm__toolbar__wrapper'>
-        <span className='cm__selection'>
-          {selectedDocs.size + selectedFolders.size} selected
-        </span>
-        {selectedDocs.size > 0 && selectedFolders.size === 0 && (
-          <>
-            <LoadingButton
-              className='cm__tool'
-              variant='bordered'
-              iconPath={mdiTagMultipleOutline}
-              onClick={(event) => {
-                openContextModal(
-                  event,
-                  <DocLabelSelectionModal
-                    selectedTags={selectedDocumentsCommonValues.tags}
-                    sendTags={sendTags}
-                  />,
-                  {
-                    alignment: 'top-left',
-                    width: 300,
-                  }
-                )
-              }}
-              disabled={selectedDocsAreUpdating}
-              spinning={sending === BulkActions.label}
-            >
-              {translate(lngKeys.GeneralLabels)}
-              {selectedDocumentsCommonValues.tags.length > 0
-                ? ` (${selectedDocumentsCommonValues.tags.length})`
-                : null}
-            </LoadingButton>
-            <DocAssigneeSelect
-              isLoading={sending === BulkActions.assignees}
-              disabled={selectedDocsAreUpdating}
-              defaultValue={selectedDocumentsCommonValues.assignees}
-              readOnly={selectedDocsAreUpdating}
-              update={sendUpdateAssignees}
-              popupAlignment='top-left'
-            />
-            <DocStatusSelect
-              status={selectedDocumentsCommonValues.status}
-              sending={sending === BulkActions.status}
-              onStatusChange={sendUpdateStatus}
-              disabled={selectedDocsAreUpdating}
-              isReadOnly={selectedDocsAreUpdating}
-              onClick={(event) => {
-                openContextModal(
-                  event,
-                  <ContentManagerToolbarStatusPopup
-                    onStatusChange={sendUpdateStatus}
-                  />,
-                  {
-                    alignment: 'top-left',
-                    width: 300,
-                  }
-                )
-              }}
-            />
-            <DocDueDateSelect
-              dueDate={selectedDocumentsCommonValues.dueDate}
-              isReadOnly={selectedDocsAreUpdating}
-              sending={sending === BulkActions.duedate}
-              shortenedLabel={true}
-              onDueDateChange={sendUpdateDocDueDate}
-            />
-          </>
-        )}
-        <LoadingButton
-          className='cm__tool'
-          variant='bordered'
-          iconPath={mdiFolderMoveOutline}
-          onClick={openMoveForm}
-          disabled={selectedDocsAreUpdating || selectedFoldersAreUpdating}
-          spinning={sending === BulkActions.move}
-        >
-          {translate(lngKeys.GeneralMoveVerb)}
-        </LoadingButton>
-        <LoadingButton
-          className='cm__tool'
-          variant='bordered'
-          iconPath={mdiTrashCanOutline}
-          onClick={bulkDeleteCallback}
-          disabled={selectedDocsAreUpdating || selectedFoldersAreUpdating}
-          spinning={sending === BulkActions.delete}
-        >
-          {translate(lngKeys.GeneralDelete)}
-        </LoadingButton>
-      </div>
-    </Container>
+    <>
+      <Container className='cm__toolbar'>
+        <div className='cm__toolbar__wrapper'>
+          <span className='cm__selection'>
+            {selectedDocs.size + selectedFolders.size} selected
+          </span>
+          {selectedDocs.size > 0 && selectedFolders.size === 0 && (
+            <>
+              <LoadingButton
+                className='cm__tool'
+                variant='bordered'
+                iconPath={mdiTagMultipleOutline}
+                onClick={(event) => {
+                  openContextModal(
+                    event,
+                    <DocLabelSelectionModal
+                      selectedTags={selectedDocumentsCommonValues.tags}
+                      sendTags={sendTags}
+                    />,
+                    {
+                      alignment: 'top-left',
+                      width: 300,
+                    }
+                  )
+                }}
+                disabled={selectedDocsAreUpdating}
+                spinning={sending === BulkActions.label}
+              >
+                {translate(lngKeys.GeneralLabels)}
+                {selectedDocumentsCommonValues.tags.length > 0
+                  ? ` (${selectedDocumentsCommonValues.tags.length})`
+                  : null}
+              </LoadingButton>
+              <DocAssigneeSelect
+                isLoading={sending === BulkActions.assignees}
+                disabled={selectedDocsAreUpdating}
+                defaultValue={selectedDocumentsCommonValues.assignees}
+                readOnly={selectedDocsAreUpdating}
+                update={sendUpdateAssignees}
+                popupAlignment='top-left'
+              />
+              <DocStatusSelect
+                status={selectedDocumentsCommonValues.status}
+                sending={sending === BulkActions.status}
+                onStatusChange={sendUpdateStatus}
+                disabled={selectedDocsAreUpdating}
+                isReadOnly={selectedDocsAreUpdating}
+                onClick={(event) => {
+                  openContextModal(
+                    event,
+                    <ContentManagerToolbarStatusPopup
+                      onStatusChange={sendUpdateStatus}
+                    />,
+                    {
+                      alignment: 'top-left',
+                      width: 300,
+                    }
+                  )
+                }}
+              />
+              <DocDueDateSelect
+                dueDate={selectedDocumentsCommonValues.dueDate}
+                isReadOnly={selectedDocsAreUpdating}
+                sending={sending === BulkActions.duedate}
+                shortenedLabel={true}
+                onDueDateChange={sendUpdateDocDueDate}
+              />
+            </>
+          )}
+          <LoadingButton
+            className='cm__tool'
+            variant='bordered'
+            iconPath={mdiFolderMoveOutline}
+            onClick={openMoveForm}
+            disabled={selectedDocsAreUpdating || selectedFoldersAreUpdating}
+            spinning={sending === BulkActions.move}
+          >
+            {translate(lngKeys.GeneralMoveVerb)}
+          </LoadingButton>
+          <LoadingButton
+            className='cm__tool'
+            variant='bordered'
+            iconPath={mdiTrashCanOutline}
+            onClick={bulkDeleteCallback}
+            disabled={selectedDocsAreUpdating || selectedFoldersAreUpdating}
+            spinning={sending === BulkActions.delete}
+          >
+            {translate(lngKeys.GeneralDelete)}
+          </LoadingButton>
+        </div>
+      </Container>
+      {sending === BulkActions.move && (
+        <BulkActionProgress bulkActionState={bulkActionState} />
+      )}
+    </>
   )
 }
 
@@ -538,7 +573,7 @@ const Container = styled.div`
 
   .cm__selection,
   .cm__tool {
-    min-wdith: 80px;
+    min-width: 80px;
     width: auto;
   }
 

--- a/src/shared/components/molecules/BulkActionProgress.tsx
+++ b/src/shared/components/molecules/BulkActionProgress.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import styled from '../../lib/styled'
+import ProgressBar from '../../../components/atoms/ProgressBar'
+import { keyframes } from 'styled-components'
+import { BulkActionState } from '../../../cloud/components/molecules/ContentManager/ContentManagerToolbar'
+
+interface BulkActionProgressProps {
+  bulkActionState: BulkActionState | null
+}
+
+function getProgressPercentage(progress: BulkActionState) {
+  return Math.max(
+    Math.min((progress.jobsCompleted / progress.jobCount) * 100, 100),
+    0
+  )
+}
+
+const BulkActionProgress = ({ bulkActionState }: BulkActionProgressProps) => (
+  <Container>
+    <ProgressBarContainer>
+      <ProgressItems>
+        <Spinner />
+        <ProgressBar
+          className='bulk__move__progress_style'
+          progress={
+            bulkActionState == null ? 0 : getProgressPercentage(bulkActionState)
+          }
+        />
+        <MoveProgressDescription>Moving..</MoveProgressDescription>
+      </ProgressItems>
+    </ProgressBarContainer>
+    <DimBackground />
+  </Container>
+)
+
+const Container = styled.div`
+  position: fixed;
+  z-index: 11000;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const MoveProgressDescription = styled.span`
+  font-size: ${({ theme }) => theme.sizes.fonts.xl}px;
+`
+
+const ProgressItems = styled.div`
+  min-width: 600px;
+  min-height: 480px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+
+  .bulk__move__progress_style {
+    background-color: ${({ theme }) =>
+      theme.colors.background.secondary} !important;
+    height: 15px;
+    border-radius: 4px;
+
+    margin-top: ${({ theme }) => theme.sizes.spaces.l}px !important;
+    margin-bottom: ${({ theme }) => theme.sizes.spaces.l}px !important;
+  }
+
+  .bulk__move__progress_style:after {
+    background-color: ${({ theme }) =>
+      theme.colors.background.quaternary} !important;
+  }
+`
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const Spinner = styled.div`
+  border-style: solid;
+  border-color: white;
+  border-right-color: transparent;
+  border-width: 2px;
+  width: 5em;
+  height: 5em;
+  display: inline-block;
+  border-radius: 50%;
+  animation: ${rotate} 0.75s linear infinite;
+`
+
+const ProgressBarContainer = styled.div`
+  position: relative;
+  z-index: 11000;
+  margin-left: 10%;
+  margin-right: 10%;
+
+  max-width: 900px;
+`
+
+const DimBackground = styled.div`
+  position: absolute;
+  z-index: 10000;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.65);
+`
+
+export default BulkActionProgress


### PR DESCRIPTION
Add progress bar when moving bulk items in folder view

Test:
In desktop application and web application:
Test moving items
User cannot cancel nor remove the move progress

Short example:

https://user-images.githubusercontent.com/18196945/129753769-1733c91d-26d8-42f9-8dcc-65ca632c4795.mp4

