### PR TITLE
Cancel previous nav data fetching

### DIFF
--- a/src/cloud/api/teams/docs/templates.ts
+++ b/src/cloud/api/teams/docs/templates.ts
@@ -5,9 +5,10 @@ export interface GetTemplatesResponseBody {
   templates: SerializedTemplate[]
 }
 
-export async function getAllTemplates(teamId: string) {
+export async function getAllTemplates(teamId: string, signal?: AbortSignal) {
   const data = await callApi<GetTemplatesResponseBody>(`api/templates`, {
     search: { teamId },
+    signal,
   })
   return data
 }

--- a/src/cloud/api/teams/resources/index.ts
+++ b/src/cloud/api/teams/resources/index.ts
@@ -47,12 +47,14 @@ export interface GetResourcesResponseBody {
 
 export async function getResources(
   teamId: string,
-  query: GetResourcesRequestQuery = { resourcesIds: [], workspacesIds: [] }
+  query: GetResourcesRequestQuery = { resourcesIds: [], workspacesIds: [] },
+  signal?: AbortSignal
 ) {
   const data = await callApi<GetResourcesResponseBody>(
     `api/teams/${teamId}/resources`,
     {
       search: querystring.stringify(query as any),
+      signal,
     }
   )
   return data


### PR DESCRIPTION
- Cancel previous nav data fetching by implementing an abort controller
- Check the abort controller again after fetching and block the update if it is already aborted. It seems there is some time gap till the browser handles aborting. So data fetching might not throw any error even if aborting is called.

# Current status
- A user opens a space
- Nav hook will fetch nav data of the space
- The use navigate to another space before the data fetching is finished.
- Nav hook will fetch again for the other space.
- Now the two nav data fetchings are in race condition
  - If the first data fetching is finished first, the nav data of the first space will be shown shortly in the second space page's nav
  - If the second data fetching is finished first, the first data fetching will overwrite nav data so the nav data from the first space will be loaded and be rendered on the second space page.
  