### PR TITLE
Add invite modal improvements

### DIFF
--- a/src/cloud/components/molecules/Help/HelpLink.tsx
+++ b/src/cloud/components/molecules/Help/HelpLink.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import Icon, { IconSize } from '../../../../shared/components/atoms/Icon'
+import styled from '../../../../shared/lib/styled'
+import { ExternalLink } from '../../../../shared/components/atoms/Link'
+import WithTooltip from '../../../../shared/components/atoms/WithTooltip'
+
+interface SettingSidenavHeaderProps {
+  iconPath: string
+  size: IconSize
+  tooltipText?: string
+  linkHref?: string
+}
+
+const HelpLink = ({
+  iconPath,
+  tooltipText,
+  size,
+  linkHref,
+}: SettingSidenavHeaderProps) => (
+  <WithTooltip tooltip={tooltipText} side={'right'}>
+    <Container className='help__header'>
+      {linkHref ? (
+        <ExternalLink href={linkHref}>
+          <Icon path={iconPath} size={size} />
+        </ExternalLink>
+      ) : (
+        <Icon path={iconPath} size={size} />
+      )}
+    </Container>
+  </WithTooltip>
+)
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${({ theme }) => theme.colors.text.subtle};
+
+  svg {
+    margin-left: ${({ theme }) => theme.sizes.spaces.xsm}px;
+  }
+`
+
+export default HelpLink

--- a/src/cloud/components/molecules/InviteCTAButton.tsx
+++ b/src/cloud/components/molecules/InviteCTAButton.tsx
@@ -12,20 +12,18 @@ import { SerializedTeam } from '../../interfaces/db/team'
 import { useI18n } from '../../lib/hooks/useI18n'
 import { lngKeys } from '../../lib/i18n/types'
 import { usePage } from '../../lib/stores/pageStore'
-import { useSettings } from '../../lib/stores/settings'
+import { mdiPlus } from '@mdi/js'
+import InviteMembersModal from './InviteMembersModal'
 
 interface InviteCTAButtonProps {
   origin?: 'folder-page' | 'doc-page'
 }
 
 const InviteCTAButton = ({ origin }: InviteCTAButtonProps) => {
-  const { translate } = useI18n()
-  const { openSettingsTab } = useSettings()
-  const { closeAllModals } = useModal()
+  const { openModal } = useModal()
 
   const onClick = useCallback(() => {
-    openSettingsTab('teamMembers')
-    closeAllModals()
+    openModal(<InviteMembersModal />, { showCloseIcon: true })
 
     switch (origin) {
       case 'folder-page':
@@ -35,14 +33,28 @@ const InviteCTAButton = ({ origin }: InviteCTAButtonProps) => {
       default:
         return
     }
-  }, [origin, openSettingsTab, closeAllModals])
+  }, [openModal, origin])
 
   return (
-    <Button variant='primary' type='button' size='sm' onClick={onClick}>
-      {translate(lngKeys.GeneralInvite)}
-    </Button>
+    <InviteButtonContainer>
+      <Button
+        type={'button'}
+        variant={'icon'}
+        iconPath={mdiPlus}
+        onClick={onClick}
+      />
+    </InviteButtonContainer>
   )
 }
+
+const InviteButtonContainer = styled.div`
+  background-color: ${({ theme }) => theme.colors.variants.primary.base};
+  border-radius: 100%;
+
+  .button__icon {
+    color: ${({ theme }) => theme.colors.variants.primary.text};
+  }
+`
 
 const EditRequestButton = ({ team }: { team: SerializedTeam }) => {
   const { translate } = useI18n()

--- a/src/cloud/components/molecules/InviteMembers/InviteMemberModalSection.tsx
+++ b/src/cloud/components/molecules/InviteMembers/InviteMemberModalSection.tsx
@@ -1,0 +1,271 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { usePage } from '../../../lib/stores/pageStore'
+import { createTeamInvite } from '../../../api/teams/invites'
+import {
+  SerializedUserTeamPermissions,
+  TeamPermissionType,
+} from '../../../interfaces/db/userTeamPermissions'
+import { mdiHelpCircleOutline, mdiPlus } from '@mdi/js'
+import { Spinner } from '../../atoms/Spinner'
+import ErrorBlock from '../../atoms/ErrorBlock'
+import Flexbox from '../../atoms/Flexbox'
+import Form from '../../../../shared/components/molecules/Form'
+import { SerializedSubscription } from '../../../interfaces/db/subscription'
+import FormRow from '../../../../shared/components/molecules/Form/templates/FormRow'
+import FormRowItem from '../../../../shared/components/molecules/Form/templates/FormRowItem'
+import { useI18n } from '../../../lib/hooks/useI18n'
+import { lngKeys } from '../../../lib/i18n/types'
+import { FormSelectOption } from '../../../../shared/components/molecules/Form/atoms/FormSelect'
+import styled from '../../../../shared/lib/styled'
+import HelpLink from '../Help/HelpLink'
+
+interface TeamInvitesSectionProps {
+  userPermissions: SerializedUserTeamPermissions
+  subscription?: SerializedSubscription
+}
+
+interface EmailData {
+  email: string
+  role: TeamPermissionType
+}
+
+const InviteMemberModalSection = ({
+  userPermissions,
+  subscription,
+}: TeamInvitesSectionProps) => {
+  const { team } = usePage()
+  const [sending, setSending] = useState<boolean>(false)
+  const [error, setError] = useState<unknown>()
+  const [role] = useState<TeamPermissionType>(
+    userPermissions.role === 'viewer'
+      ? 'viewer'
+      : subscription != null
+      ? 'member'
+      : 'viewer'
+  )
+  const [emailsToInvite, setEmailsToInvite] = useState<EmailData[]>([
+    { email: '', role: role },
+  ])
+
+  const mountedRef = useRef(false)
+  const { translate, getRoleLabel } = useI18n()
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const onChangeHandler = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>, emailIdx) => {
+      const newEmailList = emailsToInvite.map((item, idx) => {
+        if (idx === emailIdx) {
+          return {
+            ...item,
+            email: event.target.value,
+          }
+        }
+        return item
+      })
+      setEmailsToInvite(newEmailList)
+    },
+    [emailsToInvite]
+  )
+
+  const isEmailDataCorrect = useCallback((emailData: EmailData) => {
+    return emailData.email != ''
+  }, [])
+
+  const submitInvites = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault()
+      if (team == null) {
+        return
+      }
+
+      setError(undefined)
+      setSending(true)
+      try {
+        let failedInvites = 0
+        for (const email of emailsToInvite) {
+          if (isEmailDataCorrect(email)) {
+            await createTeamInvite(team, email)
+          } else {
+            failedInvites += 1
+          }
+        }
+        if (failedInvites === emailsToInvite.length) {
+          setError(translate(lngKeys.InviteFailError))
+        } else {
+          setEmailsToInvite([{ email: '', role: role }])
+        }
+      } catch (error) {
+        console.warn(error)
+        setError(error)
+      }
+      setSending(false)
+    },
+    [team, emailsToInvite, role, isEmailDataCorrect, translate]
+  )
+
+  const selectRole = useCallback(
+    (option: FormSelectOption, emailIdx: number) => {
+      if (userPermissions.role !== 'admin') {
+        return
+      }
+
+      const newEmailList = emailsToInvite.map((item, idx) => {
+        if (idx === emailIdx) {
+          return {
+            ...item,
+            role: option.value as TeamPermissionType,
+          }
+        }
+        return item
+      })
+      setEmailsToInvite(newEmailList)
+    },
+    [emailsToInvite, userPermissions.role]
+  )
+
+  const selectRoleOptions = useMemo(() => {
+    let roles: FormSelectOption[] = []
+
+    if (subscription == null) {
+      return [{ label: translate(lngKeys.GeneralViewer), value: 'viewer' }]
+    }
+
+    switch (userPermissions.role) {
+      case 'admin':
+        roles = [
+          { label: translate(lngKeys.GeneralAdmin), value: 'admin' },
+          { label: translate(lngKeys.GeneralMember), value: 'member' },
+        ]
+        break
+      case 'member':
+        roles = [{ label: translate(lngKeys.GeneralMember), value: 'member' }]
+        break
+      case 'viewer':
+      default:
+        break
+    }
+
+    roles.push({ label: translate(lngKeys.GeneralViewer), value: 'viewer' })
+    return roles
+  }, [userPermissions.role, subscription, translate])
+
+  const addMemberForm = useCallback(() => {
+    setEmailsToInvite((prev) => {
+      return [...prev, { email: '', role: role }]
+    })
+  }, [role])
+
+  return (
+    <Container>
+      <Flexbox>
+        <h2>{translate(lngKeys.InviteEmail)}</h2>
+        <HelpLink
+          iconPath={mdiHelpCircleOutline}
+          tooltipText={'Click to see role details.'}
+          size={16}
+          linkHref={
+            'https://intercom.help/boostnote-for-teams/en/articles/4354888-roles'
+          }
+        />
+        {sending && <Spinner className='relative' style={{ top: 2 }} />}
+      </Flexbox>
+
+      <Form>
+        {emailsToInvite.map((email, emailIdx) => {
+          return (
+            <FormRow key={emailIdx} fullWidth={true}>
+              <FormRowItem
+                item={{
+                  type: 'input',
+                  props: {
+                    value: email.email,
+                    onChange: (event) => onChangeHandler(event, emailIdx),
+                    placeholder: 'Email...',
+                  },
+                }}
+              />
+              <FormRowItem
+                flex='0 0 150px'
+                item={{
+                  type: 'select',
+                  props: {
+                    value: {
+                      label: getRoleLabel(email.role),
+                      value: email.role,
+                    },
+                    onChange: (option) => selectRole(option, emailIdx),
+                    options: selectRoleOptions,
+                  },
+                }}
+              />
+            </FormRow>
+          )
+        })}
+
+        <FormRow>
+          <FormRowItem
+            item={{
+              type: 'button',
+              props: {
+                variant: 'icon',
+                type: 'button',
+                iconPath: mdiPlus,
+                label: translate(lngKeys.InviteByEmailMore),
+                onClick: addMemberForm,
+              },
+            }}
+          />
+        </FormRow>
+        <FormRow>
+          <FormRowItem
+            flex='0 0 150px'
+            item={{
+              type: 'button',
+              props: {
+                type: 'submit',
+                label: translate(lngKeys.GeneralInvite),
+                onClick: submitInvites,
+                disabled: sending,
+              },
+            }}
+          />
+        </FormRow>
+      </Form>
+
+      {error != null && (
+        <ErrorContainer>
+          <ErrorBlock error={error} />
+        </ErrorContainer>
+      )}
+    </Container>
+  )
+}
+
+const ErrorContainer = styled.div`
+  margin-top: 1em;
+`
+
+const Container = styled.section`
+  small {
+    margin-top: ${({ theme }) => theme.sizes.spaces.sm}px;
+    display: block;
+  }
+
+  small a {
+    display: inline-flex;
+    white-space: nowrap;
+    &:hover {
+      svg {
+        text-decoration: underline;
+      }
+    }
+  }
+`
+
+export default InviteMemberModalSection

--- a/src/cloud/components/molecules/InviteMembersModal.tsx
+++ b/src/cloud/components/molecules/InviteMembersModal.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { usePage } from '../../lib/stores/pageStore'
+import { TeamPermissionType } from '../../interfaces/db/userTeamPermissions'
+import { useI18n } from '../../lib/hooks/useI18n'
+import SettingTabContent from '../../../shared/components/organisms/Settings/atoms/SettingTabContent'
+import ColoredBlock from '../atoms/ColoredBlock'
+import SettingTabSelector from '../../../shared/components/organisms/Settings/atoms/SettingTabSelector'
+import cc from 'classcat'
+import OpenInvitesSection from './OpenInviteSection'
+import InviteMemberModalSection from './InviteMembers/InviteMemberModalSection'
+
+const InviteMembersModal = () => {
+  const { team, currentUserPermissions } = usePage()
+  const [tab, setTab] = useState<TeamPermissionType>('member')
+  const { subscription } = usePage()
+  const mountedRef = useRef(false)
+  const { translate } = useI18n()
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  if (currentUserPermissions == null || team == null) {
+    return (
+      <SettingTabContent
+        title={translate('settings.teamMembers')}
+        body={
+          <ColoredBlock variant='danger'>
+            You don&apos;t own any permissions.
+          </ColoredBlock>
+        }
+      />
+    )
+  }
+
+  return (
+    <SettingTabContent
+      title={
+        <SettingTabSelector>
+          <button
+            className={cc([tab === 'member' && 'active'])}
+            onClick={() => setTab('member')}
+          >
+            Invite members to <i>{team.name}</i>
+          </button>
+        </SettingTabSelector>
+      }
+      description={
+        'Invite your teammates to Boost Note to start collaboration!'
+      }
+      body={
+        <>
+          <OpenInvitesSection userPermissions={currentUserPermissions} />
+          <InviteMemberModalSection
+            userPermissions={currentUserPermissions}
+            subscription={subscription}
+          />
+        </>
+      }
+    />
+  )
+}
+
+export default InviteMembersModal

--- a/src/cloud/components/molecules/OpenInviteSection.tsx
+++ b/src/cloud/components/molecules/OpenInviteSection.tsx
@@ -189,7 +189,7 @@ const OpenInvitesSection = ({ userPermissions }: OpenInvitesSectionProps) => {
   return (
     <section>
       <StyledFlex>
-        <h2 style={{ margin: 0 }}>{translate(lngKeys.InviteWithOpenLink)}</h2>
+        <h2 style={{ margin: 0 }}>{translate(lngKeys.InviteAddWithLink)}</h2>
         {userPermissions.role !== 'viewer' && (
           <Switch
             disabled={fetching || sending}

--- a/src/cloud/lib/i18n/enUS.ts
+++ b/src/cloud/lib/i18n/enUS.ts
@@ -76,8 +76,12 @@ const enTranslation: TranslationSource = {
   [lngKeys.SpaceDomain]: 'Space domain',
   [lngKeys.TeamDomainShow]: 'Your url will look like this:',
   [lngKeys.TeamDomainWarning]: "Caution: You can't change it after this step.",
-  [lngKeys.InviteWithOpenLink]: 'Invite with an open Link',
-  [lngKeys.InviteEmail]: 'Invite with Email',
+  [lngKeys.InviteRoleDetails]: 'Click to see role details.',
+  [lngKeys.InviteAddWithLink]: 'Add with link',
+  [lngKeys.InviteEmail]: 'Add by Email',
+  [lngKeys.InviteByEmailMore]: 'Add another team member',
+  [lngKeys.InviteFailError]:
+    'Invite failed because of incorrect email data. Please provide valid email and role.',
   [lngKeys.RoleMemberDescription]:
     'Members can access all features, except team management, billing.',
   [lngKeys.RoleAdminDescription]:

--- a/src/cloud/lib/i18n/fr.ts
+++ b/src/cloud/lib/i18n/fr.ts
@@ -76,8 +76,12 @@ const frTranslation: TranslationSource = {
   [lngKeys.TeamDomainShow]: "L'url sera:",
   [lngKeys.TeamDomainWarning]:
     'Attention: Vous ne pourrez pas changer de domaine après cette étape.',
-  [lngKeys.InviteWithOpenLink]: 'Inviter avec un lien ouvert',
+  [lngKeys.InviteAddWithLink]: 'Inviter avec un lien ouvert',
   [lngKeys.InviteEmail]: 'Inviter par email',
+  [lngKeys.InviteByEmailMore]: "Ajouter un autre membre de l'équipe",
+  [lngKeys.InviteFailError]:
+    "L'invitation a échoué en raison de données de courrier électronique incorrectes. Veuillez fournir une adresse e-mail et un rôle valides.",
+  [lngKeys.InviteRoleDetails]: 'Cliquez pour voir les détails du rôle.',
   [lngKeys.RoleMemberDescription]:
     "Les membres peuvent accéder à toutes les fonctionnalités excepté pour la facturation ainsi que la gestion de l'équipe.",
   [lngKeys.RoleAdminDescription]:

--- a/src/cloud/lib/i18n/ja.ts
+++ b/src/cloud/lib/i18n/ja.ts
@@ -76,8 +76,12 @@ const jpTranslation: TranslationSource = {
   [lngKeys.SpaceDomain]: 'スペースドメイン',
   [lngKeys.TeamDomainShow]: 'Urlはこのようになります：',
   [lngKeys.TeamDomainWarning]: '注意：設定後Urlを変更することはできません。',
-  [lngKeys.InviteWithOpenLink]: 'リンクでメンバー招待',
+  [lngKeys.InviteAddWithLink]: 'リンクでメンバー招待',
   [lngKeys.InviteEmail]: 'メールでメンバー招待',
+  [lngKeys.InviteByEmailMore]: '別のチームメンバーを追加する',
+  [lngKeys.InviteFailError]:
+    'メールデータが正しくないため、招待に失敗しました。有効なメールアドレスと役割を入力してください。',
+  [lngKeys.InviteRoleDetails]: 'クリックして役割の詳細を表示します。',
   [lngKeys.RoleMemberDescription]:
     'Member権限のユーザーは「チーム設定」「請求」以外の全ての機能にアクセスすることが出来ます。',
   [lngKeys.RoleAdminDescription]:

--- a/src/cloud/lib/i18n/types.ts
+++ b/src/cloud/lib/i18n/types.ts
@@ -148,8 +148,11 @@ export enum lngKeys {
   TeamDomainShow = 'team.domain.show',
   TeamDomainWarning = 'team.domain.warning',
 
-  InviteWithOpenLink = 'invite.openlink',
+  InviteAddWithLink = 'invite.url',
   InviteEmail = 'invite.email',
+  InviteByEmailMore = 'invite.more.by.email',
+  InviteFailError = 'invite.failed.invites',
+  InviteRoleDetails = 'invite.role.details.tooltip.',
   RoleMemberDescription = 'role.member.description',
   RoleAdminDescription = 'role.admin.description',
   RoleViewerDescription = 'role.viewer.description',

--- a/src/cloud/lib/i18n/zhCN.ts
+++ b/src/cloud/lib/i18n/zhCN.ts
@@ -74,8 +74,12 @@ const zhTranslation: TranslationSource = {
   [lngKeys.SpaceDomain]: '命名空间域名',
   [lngKeys.TeamDomainShow]: '您的url如下所示：',
   [lngKeys.TeamDomainWarning]: '注意：此步骤后不能更改。',
-  [lngKeys.InviteWithOpenLink]: '使用打开的链接邀请',
+  [lngKeys.InviteAddWithLink]: '使用打开的链接邀请',
   [lngKeys.InviteEmail]: '通过电子邮件邀请',
+  [lngKeys.InviteByEmailMore]: '添加另一个团队成员',
+  [lngKeys.InviteFailError]:
+    '由于电子邮件数据不正确，邀请失败。请提供有效的电子邮件和角色。',
+  [lngKeys.InviteRoleDetails]: '点击查看角色详情。',
   [lngKeys.RoleMemberDescription]:
     '成员可以访问除团队管理、计费之外的所有功能。',
   [lngKeys.RoleAdminDescription]: '管理员可以处理计费、删除或升级/降级成员。',


### PR DESCRIPTION
Add invite page in modal
Change invite button to '+'

Showcase: 

https://user-images.githubusercontent.com/18196945/130327741-dcc2b1b6-3fb3-4b75-b182-f5304f9e8180.mp4

Tested in the desktop and web app:
- Inviting members
- Setting invite roles
- Add more invite members button
- Close dialog after invite procedure (invites)


