### PR TITLE
Fix HTML export

### DIFF
--- a/src/cloud/components/DocPage/DocContextMenuActions.tsx
+++ b/src/cloud/components/DocPage/DocContextMenuActions.tsx
@@ -57,6 +57,7 @@ import {
 } from '../../api/teams/docs/exports'
 import Spinner from '../../../design/components/atoms/Spinner'
 import useApi from '../../../design/lib/hooks/useApi'
+import { usePreviewStyle } from '../../../lib/preview'
 
 export interface DocContextMenuActionsProps {
   team: SerializedTeam
@@ -84,6 +85,7 @@ export function DocContextMenuActions({
   const { subscription } = usePage()
   const { updateTemplatesMap } = useNav()
   const [copied, setCopied] = useState(false)
+  const { previewStyle } = usePreviewStyle()
 
   const docUrl = useMemo(() => {
     return boostHubBaseUrl + getDocLinkHref(doc, team, 'index')
@@ -118,12 +120,12 @@ export function DocContextMenuActions({
   }, [getUpdatedDoc])
 
   const exportAsHtml = useCallback(() => {
-    const previewStyle = defaultPreviewStyle({
+    const customizedPreviewStyle = defaultPreviewStyle({
       theme: selectV2Theme(settings['general.theme']),
-    })
+    }).concat(previewStyle)
     try {
       trackEvent(MixpanelActionTrackTypes.ExportHtml)
-      exportAsHtmlFile(getUpdatedDoc(), settings, previewStyle)
+      exportAsHtmlFile(getUpdatedDoc(), settings, customizedPreviewStyle)
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
@@ -132,7 +134,7 @@ export function DocContextMenuActions({
         description: error.message,
       })
     }
-  }, [getUpdatedDoc, settings, pushMessage])
+  }, [previewStyle, getUpdatedDoc, settings, pushMessage])
 
   const { submit: fetchDocPdf, sending: fetchingPdf } = useApi({
     api: ({


### PR DESCRIPTION
Add charts to HTML exports
Fix preview style for HTML exports
Remove unused schemes and use markdown preview one

Showcase after fixes (uploaded as txt but are HTML files):
[testhtml.txt](https://github.com/BoostIO/BoostNote-App/files/7341339/testhtml.txt)
[pdf_exporttest.txt](https://github.com/BoostIO/BoostNote-App/files/7341337/pdf_exporttest.txt)

Images (styles for admonitions, code blocks etc. are fetched from server so without it preview would be different):
![image](https://user-images.githubusercontent.com/18196945/137211011-77339b2d-fd31-4d50-9ccf-08991d2b52c6.png)
![image](https://user-images.githubusercontent.com/18196945/137211039-d4c19e33-a10b-4b92-b819-825386535203.png)
![image](https://user-images.githubusercontent.com/18196945/137211104-2df5b71d-c0d4-4bf1-afab-3bbe9164375d.png)


