### PR TITLE
Update modal rename logic

### DIFF
--- a/src/cloud/lib/hooks/useCloudResourceModals.tsx
+++ b/src/cloud/lib/hooks/useCloudResourceModals.tsx
@@ -100,9 +100,6 @@ export function useCloudResourceModals() {
           defaultInputValue={doc.title}
           defaultEmoji={doc.emoji}
           placeholder={translate(lngKeys.DocTitlePlaceholder)}
-          submitButtonProps={{
-            label: translate(lngKeys.GeneralUpdateVerb),
-          }}
           onSubmit={async (inputValue: string, emoji?: string) => {
             await updateDoc(doc, {
               workspaceId: doc.workspaceId,
@@ -112,14 +109,23 @@ export function useCloudResourceModals() {
             })
             closeLastModal()
           }}
+          onBlur={async (inputValue: string, emoji?: string) => {
+            await updateDoc(doc, {
+              workspaceId: doc.workspaceId,
+              parentFolderId: doc.parentFolderId,
+              title: inputValue,
+              emoji: emoji == null ? null : emoji,
+            })
+          }}
         />,
         {
-          showCloseIcon: true,
-          title: translate(lngKeys.RenameDoc),
+          showCloseIcon: false,
+          width: 'small',
+          hideBackground: true,
         }
       )
     },
-    [openModal, closeLastModal, updateDoc, translate]
+    [closeLastModal, openModal, translate, updateDoc]
   )
 
   const openNewFolderForm = useCallback(

--- a/src/design/components/organisms/EmojiInputForm.tsx
+++ b/src/design/components/organisms/EmojiInputForm.tsx
@@ -11,11 +11,12 @@ interface EmojiInputFormProps {
   defaultEmoji?: string
   defaultIcon: string
   inputIsDisabled?: boolean
-  submitButtonProps: ButtonProps & {
+  submitButtonProps?: ButtonProps & {
     label: React.ReactNode
     spinning?: boolean
   }
   onSubmit: (input: string, emoji?: string) => void
+  onBlur?: (input: string, emoji?: string) => void
 }
 
 const EmojiInputForm = ({
@@ -27,6 +28,7 @@ const EmojiInputForm = ({
   submitButtonProps,
   inputIsDisabled,
   onSubmit,
+  onBlur,
 }: EmojiInputFormProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [value, setValue] = useState(defaultInputValue)
@@ -60,6 +62,11 @@ const EmojiInputForm = ({
                 placeholder,
                 value: value,
                 onChange: (event) => setValue(event.target.value),
+                onBlur: () => {
+                  if (onBlur != null) {
+                    onBlur(value, emoji)
+                  }
+                },
               },
             },
           ],


### PR DESCRIPTION
Add save on focus exit (on blur)
Add auto save on enter
Shrink and set smaller modal (no title, no update button)

Showcase video:

https://user-images.githubusercontent.com/18196945/137988577-db73d160-b3e1-4885-a784-fcb46b51d4ed.mp4

Issue: https://github.com/BoostIO/BoostNote-App/issues/1148, https://github.com/Boostnote/BoostHub/issues/1337
