### PR TITLE
Fix missing dock icon

### DIFF
--- a/src/electron/windows.ts
+++ b/src/electron/windows.ts
@@ -43,6 +43,7 @@ export function createAWindow(
     minWidth: 960,
     minHeight: 630,
     show: false,
+    icon: path.join(app.getAppPath(), '../static/logo.png'),
     ...options,
   }
 


### PR DESCRIPTION
This fixes #425. This is because Ubuntu relies on the icon being set in the window itself as a hint for the dock.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#425: No icon being shown for the linux version](https://issuehunt.io/repos/74213528/issues/425)
---
</details>
<!-- /Issuehunt content-->