### PR TITLE
fix(editor): enforce spellcheck toggle on CodeMirror contenteditable

### DIFF
--- a/src/cloud/lib/editor/components/CodeMirrorEditor.tsx
+++ b/src/cloud/lib/editor/components/CodeMirrorEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import CodeMirror from '../../editor/CodeMirror'
 import { CodeMirrorBinding } from 'y-codemirror'
 import { useEffectOnce } from 'react-use'
@@ -28,6 +28,20 @@ const CodeMirrorEditor = ({
   const editorRef = useRef<CodeMirror.Editor>()
   const onScrollLineRef = useRef(onLineScroll)
   const skipOnScrollRef = useRef(false)
+
+  const applySpellcheckToInput = useCallback((enabled: boolean) => {
+    if (editorRef.current == null) {
+      return
+    }
+
+    const inputField = (editorRef.current as any).getInputField?.()
+
+    if (inputField != null) {
+      inputField.setAttribute('spellcheck', enabled ? 'true' : 'false')
+      inputField.setAttribute('autocorrect', enabled ? 'on' : 'off')
+      inputField.setAttribute('autocapitalize', enabled ? 'sentences' : 'off')
+    }
+  }, [])
 
   useEffect(() => {
     onScrollLineRef.current = onLineScroll
@@ -65,6 +79,8 @@ const CodeMirrorEditor = ({
           { leading: true, trailing: true }
         )
       )
+
+      applySpellcheckToInput(Boolean(config.spellcheck))
     }
   })
 
@@ -82,8 +98,10 @@ const CodeMirrorEditor = ({
           val
         )
       })
+
+      applySpellcheckToInput(Boolean(config.spellcheck))
     }
-  }, [config])
+  }, [config, applySpellcheckToInput])
 
   useEffect(() => {
     if (realtime == null || editorRef.current == null) {


### PR DESCRIPTION
## Summary
This fixes editor spellcheck toggle behavior for the CodeMirror contenteditable input.

### What changed
- Ensure `spellcheck` is applied directly to CodeMirror's input field (`getInputField()`).
- Apply `autocorrect` and `autocapitalize` attributes consistently with the toggle state.
- Re-apply attributes both on editor mount and whenever config updates.

## Why
The settings toggle (`general.enableSpellcheck`) existed, but browser spellcheck behavior could still fail to reflect runtime state in contenteditable mode.

## Scope
- No API changes
- No schema changes
- Frontend editor behavior only

Related issue: #695
