### PR TITLE
fix: show correct embed prompt for GitHub issue vs pull request

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -174,6 +174,7 @@ const Editor = ({
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
     pos: PositionRange
     cb: Callback
+    promptLabel?: string
   } | null>(null)
   const initialRenderDone = useRef(false)
   const { docsMap, workspacesMap, loadDoc } = useNav()
@@ -392,8 +393,8 @@ const Editor = ({
         },
       })
       pasteFormatPlugin(editor, {
-        openMenu: (pos, cb) => {
-          setShortcodeConvertMenu({ pos, cb })
+        openMenu: (pos, cb, promptLabel) => {
+          setShortcodeConvertMenu({ pos, cb, promptLabel })
         },
         closeMenu: () => {
           setShortcodeConvertMenu(null)
@@ -410,6 +411,8 @@ const Editor = ({
               return {
                 replacement: `[[ ${entityType} id="${org}/${repo}#${num}" ]]`,
                 promptMenu: true,
+                promptLabel:
+                  type === 'pull' ? 'Embed Pull Request?' : 'Embed Issue?',
               }
             }
           }
@@ -1031,6 +1034,9 @@ const Editor = ({
                     <StyledShortcodeConvertMenu
                       style={shortcodeConvertMenuStyle}
                     >
+                      {shortcodeConvertMenu.promptLabel != null && (
+                        <p>{shortcodeConvertMenu.promptLabel}</p>
+                      )}
                       <button onClick={() => shortcodeConvertMenu.cb(false)}>
                         Dismiss
                       </button>
@@ -1124,6 +1130,19 @@ const StyledShortcodeConvertMenu = styled.div`
   border-radius: 5px;
   box-shadow: ${({ theme }) => theme.colors.shadow};
 
+  p {
+    margin: 0;
+    width: 200px;
+    line-height: 25px;
+    padding: ${({ theme }) => theme.sizes.spaces.xsm}px
+      ${({ theme }) => theme.sizes.spaces.sm}px;
+    background-color: ${({ theme }) => theme.colors.background.secondary};
+    color: ${({ theme }) => theme.colors.text.primary};
+    font-size: ${({ theme }) => theme.sizes.fonts.sm}px;
+    border-radius: 5px 5px 0 0;
+    border-bottom: solid 1px ${({ theme }) => theme.colors.border.main};
+  }
+
   button {
     display: block;
     width: 200px;
@@ -1135,7 +1154,7 @@ const StyledShortcodeConvertMenu = styled.div`
     font-size: ${({ theme }) => theme.sizes.fonts.sm}px;
     text-align: left;
 
-    &:first-child {
+    &:first-of-type {
       border-radius: 5px 5px 0 0;
     }
 

--- a/src/cloud/lib/editor/plugins/pasteFormatPlugin.ts
+++ b/src/cloud/lib/editor/plugins/pasteFormatPlugin.ts
@@ -14,10 +14,15 @@ export type Callback = (convert: boolean) => void
 type FormatterResult = {
   replacement: string | null
   promptMenu: boolean
+  promptLabel?: string
 }
 
 interface Config {
-  openMenu: (position: PositionRange, callback: Callback) => void
+  openMenu: (
+    position: PositionRange,
+    callback: Callback,
+    promptLabel?: string
+  ) => void
   closeMenu: () => void
   formatter: (pasted: string[]) => FormatterResult
 }
@@ -53,7 +58,7 @@ export const pasteFormatPlugin = (
       return
     }
 
-    const { replacement, promptMenu } = formatter(change.text)
+    const { replacement, promptMenu, promptLabel } = formatter(change.text)
 
     if (replacement === null) {
       return
@@ -78,7 +83,7 @@ export const pasteFormatPlugin = (
       close()
     }
 
-    openMenu(posRange, callback)
+    openMenu(posRange, callback, promptLabel)
     open = true
   })
 }

--- a/src/cloud/lib/hooks/editor/docEditor.ts
+++ b/src/cloud/lib/hooks/editor/docEditor.ts
@@ -59,6 +59,7 @@ export function useDocEditor({
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
     pos: PositionRange
     cb: Callback
+    promptLabel?: string
   } | null>(null)
   const suggestionsRef = useRef<Hint[]>([])
   const { loadDoc } = useNav()
@@ -220,8 +221,8 @@ export function useDocEditor({
       },
     })
     pasteFormatPlugin(editor, {
-      openMenu: (pos, cb) => {
-        setShortcodeConvertMenu({ pos, cb })
+      openMenu: (pos, cb, promptLabel) => {
+        setShortcodeConvertMenu({ pos, cb, promptLabel })
       },
       closeMenu: () => {
         setShortcodeConvertMenu(null)
@@ -238,6 +239,8 @@ export function useDocEditor({
             return {
               replacement: `[[ ${entityType} id="${org}/${repo}#${num}" ]]`,
               promptMenu: true,
+              promptLabel:
+                type === 'pull' ? 'Embed Pull Request?' : 'Embed Issue?',
             }
           }
         }

--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -99,6 +99,7 @@ const Editor = ({
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
     pos: PositionRange
     cb: Callback
+    promptLabel?: string
   } | null>(null)
   const initialRenderDone = useRef(false)
   const titleRef = useRef<HTMLInputElement>(null)
@@ -277,8 +278,8 @@ const Editor = ({
       },
     })
     pasteFormatPlugin(editor, {
-      openMenu: (pos, cb) => {
-        setShortcodeConvertMenu({ pos, cb })
+      openMenu: (pos, cb, promptLabel) => {
+        setShortcodeConvertMenu({ pos, cb, promptLabel })
       },
       closeMenu: () => {
         setShortcodeConvertMenu(null)
@@ -295,6 +296,8 @@ const Editor = ({
             return {
               replacement: `[[ ${entityType} id="${org}/${repo}#${num}" ]]`,
               promptMenu: true,
+              promptLabel:
+                type === 'pull' ? 'Embed Pull Request?' : 'Embed Issue?',
             }
           }
         }
@@ -586,6 +589,9 @@ const Editor = ({
               />
               {shortcodeConvertMenu !== null && (
                 <StyledShortcodeConvertMenu style={shortcodeConvertMenuStyle}>
+                  {shortcodeConvertMenu.promptLabel != null && (
+                    <p>{shortcodeConvertMenu.promptLabel}</p>
+                  )}
                   <button onClick={() => shortcodeConvertMenu.cb(false)}>
                     Dismiss
                   </button>
@@ -649,6 +655,19 @@ const StyledShortcodeConvertMenu = styled.div`
   margin-top: ${({ theme }) => theme.sizes.spaces.xsm}px;
   border-radius: 5px;
 
+  p {
+    margin: 0;
+    width: 200px;
+    line-height: 25px;
+    padding: ${({ theme }) => theme.sizes.spaces.xsm}px
+      ${({ theme }) => theme.sizes.spaces.sm}px;
+    background-color: ${({ theme }) => theme.colors.variants.primary.base};
+    color: ${({ theme }) => theme.colors.variants.primary.text};
+    font-size: ${({ theme }) => theme.sizes.fonts.sm}px;
+    border-radius: 5px 5px 0 0;
+    border-bottom: solid 1px ${({ theme }) => theme.colors.background.quaternary};
+  }
+
   button {
     display: block;
     width: 200px;
@@ -660,7 +679,7 @@ const StyledShortcodeConvertMenu = styled.div`
     font-size: ${({ theme }) => theme.sizes.fonts.sm}px;
     text-align: left;
 
-    &:first-child {
+    &:first-of-type {
       border-radius: 5px 5px 0 0;
     }
 


### PR DESCRIPTION
## Summary
- add optional prompt label support to paste-format menu
- detect GitHub URL type and show contextual prompt text
- show Embed Pull Request? for /pull/ URLs and Embed Issue? for /issues/ URLs

## Scope
- cloud editor
- shared editor hook
- mobile editor

Closes #1149