### PR TITLE
Fix embed conversion prompt label for GitHub issues vs PRs

### DIFF
--- a/src/cloud/components/DocPreview/DocPreviewRealtime.tsx
+++ b/src/cloud/components/DocPreview/DocPreviewRealtime.tsx
@@ -200,7 +200,7 @@ const DocPreviewRealtime = ({
                     Dismiss
                   </button>
                   <button onClick={() => shortcodeConvertMenu.cb(true)}>
-                    Create embed
+                    {shortcodeConvertMenu.actionLabel ?? 'Create embed'}
                   </button>
                 </StyledShortcodeConvertMenu>
               )}

--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -174,6 +174,7 @@ const Editor = ({
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
     pos: PositionRange
     cb: Callback
+    actionLabel?: string
   } | null>(null)
   const initialRenderDone = useRef(false)
   const { docsMap, workspacesMap, loadDoc } = useNav()
@@ -392,8 +393,8 @@ const Editor = ({
         },
       })
       pasteFormatPlugin(editor, {
-        openMenu: (pos, cb) => {
-          setShortcodeConvertMenu({ pos, cb })
+        openMenu: (pos, cb, actionLabel) => {
+          setShortcodeConvertMenu({ pos, cb, actionLabel })
         },
         closeMenu: () => {
           setShortcodeConvertMenu(null)
@@ -410,6 +411,8 @@ const Editor = ({
               return {
                 replacement: `[[ ${entityType} id="${org}/${repo}#${num}" ]]`,
                 promptMenu: true,
+                actionLabel:
+                  type === 'pull' ? 'Embed pull request' : 'Embed issue',
               }
             }
           }
@@ -1035,7 +1038,7 @@ const Editor = ({
                         Dismiss
                       </button>
                       <button onClick={() => shortcodeConvertMenu.cb(true)}>
-                        Create embed
+                        {shortcodeConvertMenu.actionLabel ?? 'Create embed'}
                       </button>
                     </StyledShortcodeConvertMenu>
                   )}

--- a/src/cloud/lib/editor/plugins/pasteFormatPlugin.ts
+++ b/src/cloud/lib/editor/plugins/pasteFormatPlugin.ts
@@ -14,10 +14,15 @@ export type Callback = (convert: boolean) => void
 type FormatterResult = {
   replacement: string | null
   promptMenu: boolean
+  actionLabel?: string
 }
 
 interface Config {
-  openMenu: (position: PositionRange, callback: Callback) => void
+  openMenu: (
+    position: PositionRange,
+    callback: Callback,
+    actionLabel?: string
+  ) => void
   closeMenu: () => void
   formatter: (pasted: string[]) => FormatterResult
 }
@@ -53,7 +58,7 @@ export const pasteFormatPlugin = (
       return
     }
 
-    const { replacement, promptMenu } = formatter(change.text)
+    const { replacement, promptMenu, actionLabel } = formatter(change.text)
 
     if (replacement === null) {
       return
@@ -78,7 +83,7 @@ export const pasteFormatPlugin = (
       close()
     }
 
-    openMenu(posRange, callback)
+    openMenu(posRange, callback, actionLabel)
     open = true
   })
 }

--- a/src/cloud/lib/hooks/editor/docEditor.ts
+++ b/src/cloud/lib/hooks/editor/docEditor.ts
@@ -59,6 +59,7 @@ export function useDocEditor({
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
     pos: PositionRange
     cb: Callback
+    actionLabel?: string
   } | null>(null)
   const suggestionsRef = useRef<Hint[]>([])
   const { loadDoc } = useNav()
@@ -220,8 +221,8 @@ export function useDocEditor({
       },
     })
     pasteFormatPlugin(editor, {
-      openMenu: (pos, cb) => {
-        setShortcodeConvertMenu({ pos, cb })
+      openMenu: (pos, cb, actionLabel) => {
+        setShortcodeConvertMenu({ pos, cb, actionLabel })
       },
       closeMenu: () => {
         setShortcodeConvertMenu(null)
@@ -238,6 +239,8 @@ export function useDocEditor({
             return {
               replacement: `[[ ${entityType} id="${org}/${repo}#${num}" ]]`,
               promptMenu: true,
+              actionLabel:
+                type === 'pull' ? 'Embed pull request' : 'Embed issue',
             }
           }
         }

--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -99,6 +99,7 @@ const Editor = ({
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
     pos: PositionRange
     cb: Callback
+    actionLabel?: string
   } | null>(null)
   const initialRenderDone = useRef(false)
   const titleRef = useRef<HTMLInputElement>(null)
@@ -277,8 +278,8 @@ const Editor = ({
       },
     })
     pasteFormatPlugin(editor, {
-      openMenu: (pos, cb) => {
-        setShortcodeConvertMenu({ pos, cb })
+      openMenu: (pos, cb, actionLabel) => {
+        setShortcodeConvertMenu({ pos, cb, actionLabel })
       },
       closeMenu: () => {
         setShortcodeConvertMenu(null)
@@ -295,6 +296,8 @@ const Editor = ({
             return {
               replacement: `[[ ${entityType} id="${org}/${repo}#${num}" ]]`,
               promptMenu: true,
+              actionLabel:
+                type === 'pull' ? 'Embed pull request' : 'Embed issue',
             }
           }
         }
@@ -590,7 +593,7 @@ const Editor = ({
                     Dismiss
                   </button>
                   <button onClick={() => shortcodeConvertMenu.cb(true)}>
-                    Create embed
+                    {shortcodeConvertMenu.actionLabel ?? 'Create embed'}
                   </button>
                 </StyledShortcodeConvertMenu>
               )}


### PR DESCRIPTION
## Summary\nThis fixes the GitHub URL conversion prompt so it reflects the pasted URL type:\n-  -> **Embed pull request**\n-  -> **Embed issue**\n\nThe previous prompt used a generic action and did not clarify issue vs PR intent. This addresses #1149's request for proper distinction in the embed popup flow.\n\n## Reproduction\n1. Open markdown editor.\n2. Paste a GitHub issue URL ().\n3. Observe conversion popup text.\n\n## Before\n- Prompt action text did not distinguish issue vs PR.\n\n## After\n- Prompt action text is context-aware ( / ).\n\n## Technical changes\n- Extended paste formatter result with optional .\n- Wired  through  menu callback.\n- Updated cloud editor, doc preview realtime hook path, and mobile doc editor to render the contextual label.\n\n## Validation\n- Static code review of conversion paths in cloud + mobile editor pipelines.\n- Dependency installation for local lint timed out in this environment; code changes are intentionally minimal and type-local.\n