### PR TITLE
fix: refresh editor after comments pane resize

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -812,6 +812,16 @@ const Editor = ({
   }, [editorLayout])
 
   useEffect(() => {
+    if (editorRef.current == null) {
+      return
+    }
+
+    window.requestAnimationFrame(() => {
+      editorRef.current?.refresh()
+    })
+  }, [preferences.docContextMode])
+
+  useEffect(() => {
     focusEditorEventEmitter.listen(focusEditor)
     return () => {
       focusEditorEventEmitter.unlisten(focusEditor)


### PR DESCRIPTION
## Summary
- refresh CodeMirror after the doc context mode changes

## Why
Opening or closing the comments pane changes the editor container width, but the editor was only being refreshed when `editorLayout` changed. That leaves CodeMirror using stale dimensions and causes the cursor/viewport position to jump.

## Fix
Trigger `editorRef.current.refresh()` on `preferences.docContextMode` changes as well, using `requestAnimationFrame` so the refresh runs after the layout resize has been applied.

## Notes
This keeps the existing `editorLayout` refresh behavior and adds the missing refresh path for comment pane toggles.