### PR TITLE
fix: Can't use ctrl-c to copy text in Vim binding mode (#773)

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -269,6 +269,18 @@ const Editor = ({
         Enter: 'newlineAndIndentContinueMarkdownList',
         Tab: 'indentMore',
         'Ctrl-Space': 'autocomplete',
+        'Ctrl-C': (cm: CodeMirror.Editor) => {
+          // In Vim mode, Ctrl-C normally triggers escape. When text is
+          // selected, intercept and copy to clipboard instead so users
+          // can copy text without leaving visual/insert mode unexpectedly.
+          if (keyMap === 'vim' && cm.somethingSelected()) {
+            navigator.clipboard
+              .writeText(cm.getSelection())
+              .catch(() => document.execCommand('copy'))
+            return
+          }
+          return CodeMirror.Pass
+        },
       },
       scrollPastEnd: true,
       // fixes IME being on top of current line, Codemirror issue: https://github.com/codemirror/CodeMirror/issues/3137


### PR DESCRIPTION
## Summary

# Fix Summary — BoostNote-App #773

## Problem
In Vim binding mode, pressing Ctrl-C with text selected did not copy the text.
Instead, CodeMirror's Vim addon intercepted Ctrl-C and triggered the Vim escape action.

## Root Cause
`codemirror/keymap/vim` registers Ctrl-C as the Vim "escape" command at a lower level than `extraKeys`.
However, `extraKeys` takes priority over keymap bindings in CodeMirror, allowing us to intercept the key first.

## Fix
**File changed:** `src/cloud/components/Editor/index.tsx`

Added a `'Ctrl-C'` handler inside the `extraKeys` configuration (inside the editor options `useMemo`):

```typescript
'Ctrl-C': (cm: CodeMirror.Editor) => {
  if (keyMap === 'vim' && cm.somethingSelected()) {
    navigator.clipboard
      .writeText(cm.getSelection())
      .catch(() => document.execCommand('copy'))
    return
  }
  return CodeMirror.Pass
},
```

## Behavior After Fix
- **Vim mode + text selected**: Ctrl-C copies text to clipboard. No escape triggered.
- **Vim mode + no selection**: Ctrl-C passes through to Vim handler (escape), as expected.
- **Other keymaps (default/emacs)**: Unaffected — the `keyMap === 'vim'` guard ensures we only intercept in Vim mode.

## Files Changed
- `src/cloud/components/Editor/index.tsx` (1 block modified, ~10 lines added)


## Issue
Fixes BoostIO/BoostNote-App#773

## Changes
See diff for details.

## Testing
- Ran existing test suite where available
- Verified fix addresses the reported behavior

---
*This PR was generated with AI assistance by [argusagent](https://github.com/argusagent).*