### PR TITLE
fix: use getBoundingClientRect for header dropdown at any zoom level (fixes #1179)

### DIFF
--- a/src/cloud/components/Editor/EditorHeaderTool.tsx
+++ b/src/cloud/components/Editor/EditorHeaderTool.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef, useCallback } from 'react'
 import {
   StyledEditorToolButtonContainer,
   StyledEditorToolButton,
@@ -22,14 +22,29 @@ const EditorHeaderTool = ({
   onFormatCallback,
 }: EditorHeaderToolProps) => {
   const [openDropdown, setOpenDropdown] = useState<boolean>(false)
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({})
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Calculate dropdown position using getBoundingClientRect so it renders
+  // correctly at any browser zoom level (fixes #1179)
+  const handleButtonClick = useCallback(() => {
+    if (!openDropdown && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect()
+      setDropdownStyle({
+        position: 'fixed',
+        top: rect.top - 4,
+        left: rect.left,
+        transform: 'translateY(-100%)',
+        bottom: 'auto',
+      })
+    }
+    setOpenDropdown((prev) => !prev)
+  }, [openDropdown])
 
   return (
-    <StyledEditorToolButtonContainer>
+    <StyledEditorToolButtonContainer ref={containerRef}>
       <WithTooltip tooltip={tooltip} side='bottom'>
-        <StyledEditorToolButton
-          onClick={() => setOpenDropdown((prev) => !prev)}
-          style={style}
-        >
+        <StyledEditorToolButton onClick={handleButtonClick} style={style}>
           <Icon path={path} />
         </StyledEditorToolButton>
       </WithTooltip>
@@ -37,6 +52,7 @@ const EditorHeaderTool = ({
         <EditorHeaderToolDropdown
           onFormatCallback={onFormatCallback}
           closeDropdowndown={() => setOpenDropdown(false)}
+          dropdownStyle={dropdownStyle}
         />
       )}
     </StyledEditorToolButtonContainer>

--- a/src/cloud/components/Editor/EditorHeaderToolDropdown.tsx
+++ b/src/cloud/components/Editor/EditorHeaderToolDropdown.tsx
@@ -24,6 +24,7 @@ import Icon from '../../../design/components/atoms/Icon'
 interface EditorHeaderToolDropdownProps {
   onFormatCallback: (format: FormattingTool) => void
   closeDropdowndown: () => void
+  dropdownStyle?: React.CSSProperties
 }
 
 interface EditorHeaderToolDropdownOption {
@@ -44,6 +45,7 @@ const options: EditorHeaderToolDropdownOption[] = [
 const EditorHeaderToolDropdown = ({
   closeDropdowndown,
   onFormatCallback,
+  dropdownStyle,
 }: EditorHeaderToolDropdownProps) => {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -79,7 +81,7 @@ const EditorHeaderToolDropdown = ({
 
   return (
     <>
-      <StyledEditorToolDropdownContainer ref={menuRef} onBlur={onBlurHandler}>
+      <StyledEditorToolDropdownContainer ref={menuRef} onBlur={onBlurHandler} style={dropdownStyle}>
         {options.map((option) => (
           <ContextMenuItem
             key={option.label}


### PR DESCRIPTION
At non-100% browser zoom levels, position:absolute with bottom:100% misaligns the H1-H6 header dropdown. This fix uses getBoundingClientRect() to capture the exact button position on click and applies it as fixed position inline styles, which are accurate at any zoom level.

Fixes #1179