### PR TITLE
fix: show code block language hints immediately after typing backticks (fixes #1140)

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -363,9 +363,9 @@ const Editor = ({
       currentCursor.line == previousCursor.line
     if (
       !cm.state.completeActive &&
-      // user has started with '```x' and is waiting for options
+      // Show hints as soon as user types ``` or starts a language prefix (#1140)
       currentLine.startsWith('```') &&
-      currentLine.length >= 4 &&
+      currentLine.length >= 3 &&
       cursorColumn >= 3 &&
       !cursorsEqual
     ) {

--- a/src/cloud/lib/editor/CodeMirror.ts
+++ b/src/cloud/lib/editor/CodeMirror.ts
@@ -240,6 +240,25 @@ for (const [key, suggestions] of Object.entries(supportedModeSuggestions)) {
   })
 }
 
+// Popular languages shown when user has just typed ``` with no prefix yet
+const popularModeKeys = ['js', 'ts', 'python', 'shell', 'css', 'html', 'sql', 'go', 'rust', 'java']
+
+export function getInitialModeSuggestions(): CodeMirror.Hint[] {
+  const allSuggestions: CodeMirror.Hint[] = []
+  for (const mode of Object.values(improvedModeSuggestions as SuggestionModeType)) {
+    for (const s of mode) {
+      if (popularModeKeys.includes(s.text)) {
+        allSuggestions.push(s)
+      }
+    }
+  }
+  // Sort by the popularModeKeys order
+  allSuggestions.sort(
+    (a, b) => popularModeKeys.indexOf(a.text) - popularModeKeys.indexOf(b.text)
+  )
+  return allSuggestions
+}
+
 export function getModeSuggestions(
   word: string,
   suggestionModes: SuggestionModeType = improvedModeSuggestions
@@ -293,7 +312,12 @@ export function CodeMirrorEditorModeHints(cm: CodeMirror.Editor) {
       while (start && /\w/.test(line.charAt(start - 1))) --start
       while (end < line.length && /\w/.test(line.charAt(end))) ++end
       const word = line.slice(start, end).toLowerCase()
-      const suggestions = getModeSuggestions(word)
+      // When cursor is right after ``` with no prefix typed yet, show popular
+      // languages as a starting hint (#1140)
+      const isEmptyCodeFence = line === '```' && cursor.ch === 3
+      const suggestions = isEmptyCodeFence
+        ? getInitialModeSuggestions()
+        : getModeSuggestions(word)
       if (suggestions.length == 0) {
         return accept(null)
       }


### PR DESCRIPTION
Hints now appear as soon as the user types backtick-backtick-backtick. Popular languages (js, ts, python, shell, css, etc.) are shown when no prefix is typed yet, then filtered as the user types.

Fixes #1140