### PR TITLE
fix: prevent error when dragging folder onto doc node (fixes #1086)

### DIFF
--- a/src/cloud/lib/hooks/sidebar/useCloudDnd.ts
+++ b/src/cloud/lib/hooks/sidebar/useCloudDnd.ts
@@ -90,6 +90,13 @@ export function useCloudDnd() {
         return
       }
 
+      // A folder cannot be dropped onto a doc — only onto other folders.
+      // Without this guard the API rejects the move and shows a generic
+      // "Something wrong happened" error (#1086).
+      if (draggedResource.type === 'folder' && targetedResource.type === 'doc') {
+        return
+      }
+
       try {
         const originalResourceId = getResourceId(draggedResource)
         const pos = targetedPosition


### PR DESCRIPTION
Dragging a folder onto a doc node passed an invalid combination to the moveResource API, which rejected it and surfaced a generic error toast.

Adds an early-return guard in dropInDocOrFolder: if the dragged resource is a folder and the drop target is a doc, silently ignore the drop.

Fixes #1086