### PR TITLE
Fix Vim Ctrl-C copy shortcut

### DIFF
--- a/src/cloud/lib/editor/components/CodeMirrorEditor.tsx
+++ b/src/cloud/lib/editor/components/CodeMirrorEditor.tsx
@@ -16,6 +16,33 @@ interface EditorProps {
   onYTextChange?: (event: YEvent, ytext: YText) => void
 }
 
+const defaultExtraKeys: CodeMirror.KeyMap = {
+  Enter: 'newlineAndIndentContinueMarkdownList',
+  Tab: 'indentMore',
+  'Ctrl-C': (cm: CodeMirror.Editor) => {
+    if (cm.getOption('keyMap') === 'vim') {
+      document.execCommand('copy')
+    }
+    return CodeMirror.Pass
+  },
+}
+
+function buildEditorConfig(
+  config: CodeMirror.EditorConfiguration
+): CodeMirror.EditorConfiguration {
+  if (typeof config.extraKeys === 'string') {
+    return config
+  }
+
+  return {
+    ...config,
+    extraKeys: {
+      ...defaultExtraKeys,
+      ...config.extraKeys,
+    },
+  }
+}
+
 const CodeMirrorEditor = ({
   config = {},
   realtime,
@@ -35,13 +62,10 @@ const CodeMirrorEditor = ({
 
   useEffectOnce(() => {
     if (editorRootRef.current != null) {
-      editorRef.current = CodeMirror(editorRootRef.current, {
-        extraKeys: {
-          Enter: 'newlineAndIndentContinueMarkdownList',
-          Tab: 'indentMore',
-        },
-        ...config,
-      })
+      editorRef.current = CodeMirror(
+        editorRootRef.current,
+        buildEditorConfig(config)
+      )
 
       editorRef.current.on('keydown', (cm, event) => {
         if (cm.state.vim && cm.state.vim.insertMode) {
@@ -76,7 +100,7 @@ const CodeMirrorEditor = ({
 
   useEffect(() => {
     if (editorRef.current != null) {
-      Object.entries(config).forEach(([key, val]) => {
+      Object.entries(buildEditorConfig(config)).forEach(([key, val]) => {
         editorRef.current!.setOption(
           key as keyof CodeMirror.EditorConfiguration,
           val


### PR DESCRIPTION
Fixes #773.

IssueHunt bounty: https://issuehunt.io/r/BoostIO/BoostNote-App/issues/773

## Reproduction

The issue report describes Vim keymap mode on Windows/Linux where `Ctrl-C` exits Vim insert mode instead of copying the selected editor text to the clipboard. A maintainer pointed to the old Boostnote fix and suggested adding an extra CodeMirror key binding in the editor setup.

## Changes

- Adds a shared CodeMirror `Ctrl-C` extra key for Vim keymap mode.
- Calls the browser copy command before returning `CodeMirror.Pass`, preserving the existing Vim key handling after the copy attempt.
- Merges the default editor extra keys with per-editor config extra keys so the copy binding is not lost when editor configs provide their own `extraKeys`.

## Verification

- `./node_modules/.bin/eslint src/cloud/lib/editor/components/CodeMirrorEditor.tsx --ext .tsx`
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `git diff --check`
