### PR TITLE
Keep header dropdown labels on one line

### DIFF
--- a/src/cloud/components/Editor/EditorHeaderToolDropdown.tsx
+++ b/src/cloud/components/Editor/EditorHeaderToolDropdown.tsx
@@ -105,12 +105,15 @@ export default EditorHeaderToolDropdown
 const StyledMenuItem = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  width: 100%;
+  white-space: nowrap;
 `
 
 const StyledIcon = styled.div`
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
   padding-right: ${({ theme }) => theme.sizes.spaces.sm}px;
   font-size: 21px;
 `

--- a/src/cloud/components/Editor/styled.ts
+++ b/src/cloud/components/Editor/styled.ts
@@ -47,9 +47,10 @@ export const StyledEditorToolDropdownContainer = styled.div`
   z-index: 9000;
   position: absolute;
   padding: ${({ theme }) => theme.sizes.spaces.xsm}px 0;
-  width: 110px;
+  width: 132px;
   height: auto;
   min-width: 100%;
+  box-sizing: border-box;
   border-style: solid;
   border-width: 1px;
   border-radius: 4px;


### PR DESCRIPTION
Fixes #1179.

## Summary
- widen the editor header dropdown so icon, padding, and label fit at non-default zoom levels
- keep the header menu labels on a single line
- keep icon sizing stable so labels do not wrap around the icon

## Verification
- npx prettier --write src/cloud/components/Editor/styled.ts src/cloud/components/Editor/EditorHeaderToolDropdown.tsx
- npx eslint src/cloud/components/Editor/styled.ts src/cloud/components/Editor/EditorHeaderToolDropdown.tsx --ext .ts,.tsx
- npx tsc --noEmit --pretty false
- git diff --check


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1179: Add header text (Toolbar) breaks with non default zoom value](https://oss.issuehunt.io/repos/74213528/issues/1179)
---
</details>
<!-- /Issuehunt content-->