### PR TITLE
Enable Android cursor drag positioning

### DIFF
--- a/src/mobile/components/pages/DocEditPage.tsx
+++ b/src/mobile/components/pages/DocEditPage.tsx
@@ -55,6 +55,7 @@ import {
 } from '../../../cloud/lib/subscription'
 import CustomizedMarkdownPreviewer from '../../../cloud/components/MarkdownView/CustomizedMarkdownPreviewer'
 import { scrollEditorToLine } from '../../../cloud/lib/hooks/editor/docEditor'
+import { attachTouchCursorDrag } from '../../lib/codeMirrorTouchCursor'
 
 interface EditorProps {
   doc: SerializedDocWithSupplemental
@@ -94,6 +95,7 @@ const Editor = ({
   const [initialLoadDone, setInitialLoadDone] = useState(false)
   const [editorContent, setEditorContent] = useState('')
   const editorRef = useRef<CodeMirror.Editor | null>(null)
+  const touchCursorDragDisposerRef = useRef<() => void>()
   const fileUploadHandlerRef = useRef<OnFileCallback>()
   const docRef = useRef<string>('')
   const [shortcodeConvertMenu, setShortcodeConvertMenu] = useState<{
@@ -269,6 +271,9 @@ const Editor = ({
   const bindCallback = useCallback((editor: CodeMirror.Editor) => {
     setEditorContent(editor.getValue())
     editorRef.current = editor
+    if (osName === 'android' && touchCursorDragDisposerRef.current == null) {
+      touchCursorDragDisposerRef.current = attachTouchCursorDrag(editor)
+    }
     attachFileHandlerToCodeMirrorEditor(editor, {
       onFile: async (file) => {
         return fileUploadHandlerRef.current != null
@@ -364,6 +369,15 @@ const Editor = ({
         currentSelections: selections,
       })
     })
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (touchCursorDragDisposerRef.current != null) {
+        touchCursorDragDisposerRef.current()
+        touchCursorDragDisposerRef.current = undefined
+      }
+    }
   }, [])
 
   useEffect(() => {
@@ -755,6 +769,10 @@ const StyledEditor = styled.div`
     height: 100%;
     position: relative;
     z-index: 0 !important;
+    &.CodeMirror-touch-cursor-dragging {
+      cursor: text;
+      user-select: none;
+    }
     .CodeMirror-hints {
       position: absolute;
       z-index: 10;

--- a/src/mobile/lib/codeMirrorTouchCursor.ts
+++ b/src/mobile/lib/codeMirrorTouchCursor.ts
@@ -1,0 +1,125 @@
+const longPressDelay = 350
+const movementTolerance = 8
+
+interface TouchCursorState {
+  active: boolean
+  startX: number
+  startY: number
+  timer: number
+}
+
+const getTouchDistance = (touch: Touch, state: TouchCursorState) => {
+  const x = touch.clientX - state.startX
+  const y = touch.clientY - state.startY
+
+  return Math.sqrt(x * x + y * y)
+}
+
+export function attachTouchCursorDrag(editor: CodeMirror.Editor) {
+  const wrapperElement = editor.getWrapperElement()
+  let state: TouchCursorState | null = null
+
+  const clearState = () => {
+    if (state != null) {
+      window.clearTimeout(state.timer)
+      state = null
+    }
+
+    wrapperElement.classList.remove('CodeMirror-touch-cursor-dragging')
+  }
+
+  const moveCursorToTouch = (touch: Touch) => {
+    const pos = editor.coordsChar({
+      left: touch.pageX,
+      top: touch.pageY,
+    })
+
+    editor.focus()
+    editor.setCursor(pos)
+    editor.scrollIntoView(pos, 30)
+  }
+
+  const onTouchStart = (event: TouchEvent) => {
+    clearState()
+
+    if (event.touches.length !== 1) {
+      return
+    }
+
+    const touch = event.touches[0]
+
+    state = {
+      active: false,
+      startX: touch.clientX,
+      startY: touch.clientY,
+      timer: window.setTimeout(() => {
+        if (state == null) {
+          return
+        }
+
+        state.active = true
+        wrapperElement.classList.add('CodeMirror-touch-cursor-dragging')
+        moveCursorToTouch(touch)
+      }, longPressDelay),
+    }
+  }
+
+  const onTouchMove = (event: TouchEvent) => {
+    if (state == null || event.touches.length !== 1) {
+      clearState()
+      return
+    }
+
+    const touch = event.touches[0]
+
+    if (!state.active) {
+      if (getTouchDistance(touch, state) > movementTolerance) {
+        clearState()
+      }
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    moveCursorToTouch(touch)
+  }
+
+  const onTouchEnd = (event: TouchEvent) => {
+    if (state?.active) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    clearState()
+  }
+
+  const onContextMenu = (event: MouseEvent) => {
+    if (state?.active) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
+
+  wrapperElement.addEventListener('touchstart', onTouchStart, {
+    passive: true,
+  })
+  wrapperElement.addEventListener('touchmove', onTouchMove, {
+    passive: false,
+  })
+  wrapperElement.addEventListener('touchend', onTouchEnd, {
+    passive: false,
+  })
+  wrapperElement.addEventListener('touchcancel', onTouchEnd, {
+    passive: false,
+  })
+  wrapperElement.addEventListener('contextmenu', onContextMenu)
+
+  return () => {
+    clearState()
+    wrapperElement.removeEventListener('touchstart', onTouchStart)
+    wrapperElement.removeEventListener('touchmove', onTouchMove)
+    wrapperElement.removeEventListener('touchend', onTouchEnd)
+    wrapperElement.removeEventListener('touchcancel', onTouchEnd)
+    wrapperElement.removeEventListener('contextmenu', onContextMenu)
+  }
+}


### PR DESCRIPTION
Closes #443

IssueHunt bounty: https://issuehunt.io/r/BoostIO/BoostNote-App/issues/443

## Summary
- add an Android-only long-press cursor drag handler for the mobile CodeMirror editor
- move the cursor with `coordsChar`/`setCursor` while dragging after the long press activates
- clean up touch/context-menu listeners when the editor unmounts, while leaving normal tap/scroll gestures alone before activation

## Validation
- `npm exec --package prettier@2.5.1 -- prettier --check src/mobile/lib/codeMirrorTouchCursor.ts src/mobile/components/pages/DocEditPage.tsx`
- `git diff --check`

I could not run the full project test suite locally because installing the existing dependency tree exhausted the `/tmp` tmpfs in this environment.
