### PR TITLE
Add copy note link action to sidebar context menus

### DIFF
--- a/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
+++ b/src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 import {
   mdiCog,
+  mdiContentCopy,
   mdiFileDocumentOutline,
   mdiTextBoxPlus,
   mdiFolderPlusOutline,
@@ -13,6 +14,7 @@ import {
   mdiTrashCanOutline,
   mdiViewDashboard,
 } from '@mdi/js'
+import copy from 'copy-to-clipboard'
 import { FoldingProps } from '../../../../design/components/atoms/FoldingWrapper'
 import { SidebarDragState } from '../../../../design/lib/dnd'
 import {
@@ -483,6 +485,12 @@ export function useCloudSidebarTree() {
               contextControls: [
                 {
                   type: MenuTypes.Normal,
+                  icon: mdiContentCopy,
+                  label: translate(lngKeys.GeneralCopyTheLink),
+                  onClick: () => copy(href),
+                },
+                {
+                  type: MenuTypes.Normal,
                   icon: doc.bookmarked ? mdiStar : mdiStarOutline,
                   label:
                     treeSendingMap.get(doc.id) === 'bookmark'
@@ -513,6 +521,14 @@ export function useCloudSidebarTree() {
                   icon: doc.bookmarked ? mdiStar : mdiStarOutline,
                   onClick: () =>
                     toggleDocBookmark(doc.teamId, doc.id, doc.bookmarked),
+                },
+              ],
+              contextControls: [
+                {
+                  type: MenuTypes.Normal,
+                  icon: mdiContentCopy,
+                  label: translate(lngKeys.GeneralCopyTheLink),
+                  onClick: () => copy(href),
                 },
               ],
             }

--- a/src/mobile/lib/sidebar/useNavigatorTree.tsx
+++ b/src/mobile/lib/sidebar/useNavigatorTree.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, MouseEvent } from 'react'
 import {
   mdiCog,
+  mdiContentCopy,
   mdiFileDocumentOutline,
   mdiFilePlusOutline,
   mdiFolderPlusOutline,
@@ -14,6 +15,7 @@ import {
   mdiWeb,
   mdiDotsHorizontal,
 } from '@mdi/js'
+import copy from 'copy-to-clipboard'
 import { FoldingProps } from '../../../design/components/atoms/FoldingWrapper'
 import { SidebarTreeSortingOrder } from '../../../design/lib/sidebar'
 import {
@@ -403,6 +405,12 @@ export function useNavigatorTree() {
               contextControls: [
                 {
                   type: MenuTypes.Normal,
+                  icon: mdiContentCopy,
+                  label: 'Copy the link',
+                  onClick: () => copy(href),
+                },
+                {
+                  type: MenuTypes.Normal,
                   icon: doc.bookmarked ? mdiStar : mdiStarOutline,
                   label:
                     treeSendingMap.get(doc.id) === 'bookmark'
@@ -433,6 +441,14 @@ export function useNavigatorTree() {
                   icon: doc.bookmarked ? mdiStar : mdiStarOutline,
                   onClick: () =>
                     toggleDocBookmark(doc.teamId, doc.id, doc.bookmarked),
+                },
+              ],
+              contextControls: [
+                {
+                  type: MenuTypes.Normal,
+                  icon: mdiContentCopy,
+                  label: 'Copy the link',
+                  onClick: () => copy(href),
                 },
               ],
             }


### PR DESCRIPTION
Fixes #313.

## Summary
- Add a `Copy the link` action to document context menus in the cloud sidebar.
- Add the same action to the mobile navigator tree so copied note links are available consistently.
- Use the existing absolute document href and `copy-to-clipboard`, matching the app's existing copy-link behavior in document metadata/actions.
- Keep rename/delete restricted to core members while allowing copy-link for non-core users too.

## Validation
- `npx tsc --noEmit --pretty false`
- `npx prettier --check "src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx" "src/mobile/lib/sidebar/useNavigatorTree.tsx"`
- `npx eslint "src/cloud/lib/hooks/sidebar/useCloudSidebarTree.tsx" "src/mobile/lib/sidebar/useNavigatorTree.tsx"`
- `git diff --check`