### PR TITLE
Use light theme for PDF export

### DIFF
--- a/src/cloud/components/DocPage/DocContextMenuActions.tsx
+++ b/src/cloud/components/DocPage/DocContextMenuActions.tsx
@@ -34,6 +34,7 @@ import {
   exportAsMarkdownFile,
   exportAsHtmlFile,
   filenamifyTitle,
+  pdfExportTheme,
 } from '../../lib/export'
 import { downloadBlob } from '../../../design/lib/dom'
 import { useNav } from '../../lib/stores/nav'
@@ -219,7 +220,7 @@ export function DocContextMenuActions({
       await fetchDocPdf({
         updatedDoc,
         exportOptions: {
-          appTheme: settings['general.theme'],
+          appTheme: pdfExportTheme,
           codeBlockTheme: settings['general.codeBlockTheme'],
         },
         token,

--- a/src/cloud/lib/export.ts
+++ b/src/cloud/lib/export.ts
@@ -37,6 +37,8 @@ const remarkAdmonitionOptions = {
   infima: false,
 }
 
+export const pdfExportTheme = 'light'
+
 export const exportAsHtmlFile = async (
   doc: SerializedDoc,
   preferences: UserSettings,
@@ -122,7 +124,10 @@ const fetchCorrectMdThemeName = (theme: string, appTheme: string) => {
   return theme
 }
 
-const getCssLinks = (settings: UserSettings) => {
+const getCssLinks = (
+  settings: UserSettings,
+  appTheme = settings['general.theme']
+) => {
   const cssHrefs: string[] = []
 
   cssHrefs.push(boostHubBaseUrl + '/app/codemirror/theme/codemirror.css')
@@ -131,7 +136,7 @@ const getCssLinks = (settings: UserSettings) => {
 
   const editorTheme = fetchCorrectMdThemeName(
     settings['general.editorTheme'],
-    settings['general.theme']
+    appTheme
   )
   if (editorTheme != null) {
     const editorThemePath =
@@ -141,7 +146,7 @@ const getCssLinks = (settings: UserSettings) => {
 
   const markdownCodeBlockTheme = fetchCorrectMdThemeName(
     settings['general.codeBlockTheme'],
-    settings['general.theme']
+    appTheme
   )
   if (
     markdownCodeBlockTheme != null &&
@@ -162,12 +167,11 @@ const generatePrintToPdfHTML = (
   settings: UserSettings,
   previewStyle?: string
 ) => {
-  const cssHrefs: string[] = getCssLinks(settings)
-  const generalThemeName = settings['general.theme']
+  const cssHrefs: string[] = getCssLinks(settings, pdfExportTheme)
   const cssLinks = cssHrefs
     .map((href) => cssStyleLinkGenerator(href))
     .join('\n')
-  const themedGlobalCss = getGlobalCss(selectV2Theme(generalThemeName))
+  const themedGlobalCss = getGlobalCss(selectV2Theme(pdfExportTheme))
   const previewStyleCssEl = previewStyle ? `` : ''
 
   return `<!DOCTYPE html>
@@ -189,7 +193,7 @@ const generatePrintToPdfHTML = (
         </style>
       </head>
       <body>
-        <div class="${generalThemeName}">
+        <div class="${pdfExportTheme}">
           ${markdownHTML}
         </div>
       </body>


### PR DESCRIPTION
Closes #912

IssueHunt bounty: https://issuehunt.io/r/BoostIO/BoostNote-App/issues/912

## Summary
- force PDF export rendering to use the light app theme instead of the active UI theme
- resolve default editor/code-block theme CSS against light mode for generated PDF HTML
- send `appTheme: light` to the cloud PDF export endpoint so dark UI themes do not produce dark PDFs

## Validation
- `npm exec --package prettier@2.5.1 -- prettier --check src/cloud/lib/export.ts src/cloud/components/DocPage/DocContextMenuActions.tsx`
- `git diff --check`

I could not run the full project test suite locally because installing the existing dependency tree exhausted the `/tmp` tmpfs in this environment.
