### PR TITLE
Restore copy behavior in Vim keymap

### DIFF
--- a/src/cloud/components/Editor/index.tsx
+++ b/src/cloud/components/Editor/index.tsx
@@ -104,6 +104,7 @@ import {
   CodeMirrorEditorModeHints,
   getModeSuggestions,
 } from '../../lib/editor/CodeMirror'
+import { copySelectionOnVimCtrlC } from '../../lib/editor/vimKeyMap'
 import { scrollEditorToLine } from '../../lib/hooks/editor/docEditor'
 
 type LayoutMode = 'split' | 'preview' | 'editor'
@@ -269,6 +270,7 @@ const Editor = ({
         Enter: 'newlineAndIndentContinueMarkdownList',
         Tab: 'indentMore',
         'Ctrl-Space': 'autocomplete',
+        'Ctrl-C': copySelectionOnVimCtrlC,
       },
       scrollPastEnd: true,
       // fixes IME being on top of current line, Codemirror issue: https://github.com/codemirror/CodeMirror/issues/3137

--- a/src/cloud/lib/editor/vimKeyMap.ts
+++ b/src/cloud/lib/editor/vimKeyMap.ts
@@ -1,0 +1,9 @@
+import CodeMirror from 'codemirror'
+
+export function copySelectionOnVimCtrlC(cm: CodeMirror.Editor) {
+  if (`${cm.getOption('keyMap')}`.startsWith('vim')) {
+    document.execCommand('copy')
+  }
+
+  return CodeMirror.Pass
+}

--- a/src/cloud/lib/hooks/editor/docEditor.ts
+++ b/src/cloud/lib/hooks/editor/docEditor.ts
@@ -12,6 +12,7 @@ import { SerializedTeam } from '../../../interfaces/db/team'
 import { SerializedTemplate } from '../../../interfaces/db/template'
 import { SerializedUser } from '../../../interfaces/db/user'
 import useRealtime from '../../editor/hooks/useRealtime'
+import { copySelectionOnVimCtrlC } from '../../editor/vimKeyMap'
 import attachFileHandlerToCodeMirrorEditor, {
   OnFileCallback,
 } from '../../editor/plugins/fileHandler'
@@ -132,6 +133,7 @@ export function useDocEditor({
       extraKeys: {
         Enter: 'newlineAndIndentContinueMarkdownList',
         Tab: 'indentMore',
+        'Ctrl-C': copySelectionOnVimCtrlC,
       },
       scrollPastEnd: true,
       // fixes IME being on top of current line, Codemirror issue: https://github.com/codemirror/CodeMirror/issues/3137


### PR DESCRIPTION
## Summary
- add a shared CodeMirror Vim Ctrl-C handler that runs the browser copy command for Vim editors
- attach it to both cloud editor configurations so selected text can be copied on Windows/Linux while preserving CodeMirror's normal handling

Fixes #773.

## Verification
- npm ci --ignore-scripts --prefer-offline
- npx eslint src/cloud/lib/editor/vimKeyMap.ts src/cloud/components/Editor/index.tsx src/cloud/lib/hooks/editor/docEditor.ts --ext .ts,.tsx
- npx tsc --noEmit --pretty false

## Notes
- Not manually verified in Electron on Windows/Linux.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#773: Can't use ctrl-c to copy text in Vim binding mode](https://oss.issuehunt.io/repos/74213528/issues/773)
---
</details>
<!-- /Issuehunt content-->