### PR TITLE
Apply Linux no-sandbox launch flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,6 +273,9 @@
     },
     "linux": {
       "icon": "static/icon.icns",
+      "executableArgs": [
+        "--no-sandbox"
+      ],
       "target": [
         "deb",
         "rpm",

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -15,7 +15,14 @@ function applyMenuTemplate(template: MenuItemConstructorOptions[]) {
 }
 
 const mac = process.platform === 'darwin'
+const linux = process.platform === 'linux'
 let ready = false
+
+if (linux && app.isPackaged && !process.argv.includes('--no-sandbox')) {
+  // Debian-based systems can abort before opening a window when the packaged
+  // chrome-sandbox helper is not installed with setuid permissions.
+  app.commandLine.appendSwitch('no-sandbox')
+}
 
 const singleInstance = app.requestSingleInstanceLock()
 if (!singleInstance) {


### PR DESCRIPTION
## Summary
- add `--no-sandbox` to Linux package launcher args
- append the same Electron command-line switch in the packaged Linux main process before `ready`
- avoid duplicating the switch when it is already present from launcher metadata

This covers both desktop launcher startup and direct AppImage/deb binary startup for Debian-based systems where Electron aborts on a misconfigured `chrome-sandbox` helper.

Closes #244.

## Verification
- `node -e` electron-builder config validation for `package.json#build`
- `npx npm@6 run lint`
- `npx npm@6 run test-api -- --runInBand`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/prettier --check package.json src/electron/index.ts`
- `git diff --check`
- `NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production BOOST_HUB_BASE_URL=https://boostnote.io ./node_modules/.bin/ts-node -P tsconfig-webpack.json scripts/build-electron-main.ts`
